### PR TITLE
Add shared transaction leg validation and tests

### DIFF
--- a/apps/api/shared/__init__.py
+++ b/apps/api/shared/__init__.py
@@ -39,7 +39,7 @@ from .settings import (
     DB_USER_ENV,
     DatabaseSettings,
 )
-from .validation import ensure_balanced_legs
+from .validation import ensure_balanced_legs, validate_transaction_legs
 from .views import create_or_replace_materialized_views
 
 __all__ = [
@@ -69,6 +69,7 @@ __all__ = [
     "session_scope",
     "init_db",
     "ensure_balanced_legs",
+    "validate_transaction_legs",
     "coerce_decimal",
     "validate_category_amount",
     "DatabaseSettings",


### PR DESCRIPTION
## Summary
- centralize transaction leg validation in a shared helper covering balance, polarity, non-zero amounts, and transfer account uniqueness
- apply the unified validator in transaction service and repository
- expand transaction creation edge case tests (single leg, zero amount, imbalance, all-positive/all-negative, same-account transfer)

## Testing
- make format
- make type-check
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945cadb1fa4832db284c730cd4eacde)