### PR TITLE
Refactor import preview helpers

### DIFF
--- a/apps/api/services/imports/__init__.py
+++ b/apps/api/services/imports/__init__.py
@@ -1,0 +1,5 @@
+"""Import service package."""
+
+from .service import CategorySuggestion, ImportService, RuleMatch, SubscriptionSuggestion
+
+__all__ = ["ImportService", "CategorySuggestion", "SubscriptionSuggestion", "RuleMatch"]

--- a/apps/api/services/imports/parsers/__init__.py
+++ b/apps/api/services/imports/parsers/__init__.py
@@ -1,0 +1,56 @@
+"""Bank-specific parser strategies for import previews."""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional, Protocol
+
+from openpyxl import load_workbook
+from openpyxl.utils.exceptions import InvalidFileException
+
+from ....shared import BankImportType
+from ..utils import parse_iso_date
+from .circle_k_mastercard import parse_circle_k_mastercard
+from .seb import parse_seb
+from .swedbank import parse_swedbank
+from .types import NormalizedRow, ParseResult
+
+
+class BankParser(Protocol):
+    def __call__(
+        self, sheet: Any, *, parse_date: Callable[[str], Optional[datetime]]
+    ) -> ParseResult: ...
+
+
+_PARSER_MAP: Dict[BankImportType, BankParser] = {
+    BankImportType.CIRCLE_K_MASTERCARD: parse_circle_k_mastercard,
+    BankImportType.SEB: parse_seb,
+    BankImportType.SWEDBANK: parse_swedbank,
+}
+
+
+def parse_bank_rows(*, filename: str, content: bytes, bank_type: BankImportType) -> ParseResult:
+    """Load the workbook and delegate to the appropriate bank parser."""
+
+    name = filename.lower()
+    if not name.endswith(".xlsx"):
+        return ([], [(0, "Unsupported file type; only XLSX exports are accepted")])
+
+    try:
+        workbook = load_workbook(filename=io.BytesIO(content), read_only=True, data_only=True)
+    except (InvalidFileException, OSError, ValueError) as exc:  # pragma: no cover - defensive
+        return ([], [(0, f"Unable to read XLSX file: {exc}")])
+
+    sheet = workbook.active
+    if sheet is None:
+        return ([], [(0, "XLSX workbook has no active sheet")])
+
+    parser = _PARSER_MAP.get(bank_type)
+    if parser is None:
+        return ([], [(0, "Unknown bank type")])
+
+    return parser(sheet, parse_date=parse_iso_date)
+
+
+__all__ = ["NormalizedRow", "ParseResult", "parse_bank_rows"]

--- a/apps/api/services/imports/parsers/circle_k_mastercard.py
+++ b/apps/api/services/imports/parsers/circle_k_mastercard.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Dict, List, Optional, Tuple
+
+from ..utils import clean_header, clean_value, parse_decimal_value
+from .types import NormalizedRow, ParseResult
+
+
+def parse_circle_k_mastercard(
+    sheet,
+    *,
+    parse_date: Callable[[str], Optional[datetime]],
+) -> ParseResult:
+    """Parse Circle K Mastercard exports."""
+
+    header_map: Dict[str, int] | None = None
+    rows: List[NormalizedRow] = []
+    errors: List[Tuple[int, str]] = []
+
+    for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+        cleaned = [clean_value(cell) for cell in row]
+        if header_map is None:
+            candidate_headers = {
+                clean_header(val): pos for pos, val in enumerate(row) if val is not None
+            }
+            if {"datum", "belopp"}.issubset(candidate_headers.keys()):
+                header_map = candidate_headers
+            continue
+        if not any(cleaned):
+            continue
+        first_cell = cleaned[0].lower() if cleaned and isinstance(cleaned[0], str) else ""
+        if first_cell == "datum":
+            candidate_headers = {
+                clean_header(val): pos for pos, val in enumerate(row) if val is not None
+            }
+            if {"datum", "belopp"}.issubset(candidate_headers.keys()):
+                header_map = candidate_headers
+            continue
+        if "totalt belopp" in first_cell:
+            continue
+        if "summa" in first_cell or (
+            len(cleaned) > 2 and isinstance(cleaned[2], str) and "summa" in cleaned[2].lower()
+        ):
+            continue
+
+        try:
+            date_idx = header_map.get("datum", 0)
+            date_text = cleaned[date_idx] if date_idx < len(cleaned) else ""
+
+            description_idx = header_map.get("specifikation", 2)
+            description = cleaned[description_idx] if description_idx < len(cleaned) else ""
+
+            location_idx = header_map.get("ort", 3)
+            location = cleaned[location_idx] if location_idx < len(cleaned) else ""
+            if location:
+                description = f"{description} ({location})" if description else str(location)
+
+            amount_idx = header_map.get("belopp", 6)
+            amount_raw = cleaned[amount_idx] if amount_idx < len(cleaned) else ""
+
+            occurred_at = parse_date(str(date_text))
+            if occurred_at is None:
+                if date_text and description and amount_raw != "":
+                    raise ValueError("invalid date")
+                continue
+            if amount_raw == "":
+                continue
+            amount = parse_decimal_value(amount_raw)
+            if amount is None:
+                raise ValueError("invalid amount")
+            amount = -abs(amount)
+            rows.append(
+                {
+                    "date": occurred_at.isoformat(),
+                    "description": description,
+                    "amount": str(amount),
+                }
+            )
+        except (ValueError, TypeError, IndexError) as exc:  # pragma: no cover - defensive
+            errors.append((idx, f"Unable to parse row: {exc}"))
+
+    if header_map is None:
+        errors.append((0, "Circle K Mastercard export is missing the expected headers"))
+
+    return rows, errors
+
+
+__all__ = ["parse_circle_k_mastercard"]

--- a/apps/api/services/imports/parsers/seb.py
+++ b/apps/api/services/imports/parsers/seb.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Dict, List, Optional, Tuple
+
+from ..utils import clean_header, clean_value, parse_decimal_value
+from .types import NormalizedRow, ParseResult
+
+
+def parse_seb(
+    sheet,
+    *,
+    parse_date: Callable[[str], Optional[datetime]],
+) -> ParseResult:
+    """Parse SEB statement exports."""
+
+    header_index = None
+    headers: Dict[str, int] = {}
+    rows: List[NormalizedRow] = []
+    errors: List[Tuple[int, str]] = []
+
+    for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+        header_map = {clean_header(val): pos for pos, val in enumerate(row) if val}
+        if not header_index and {"bokförd", "insättningar/uttag"}.issubset(header_map.keys()):
+            header_index = idx
+            headers = header_map
+            continue
+        if header_index is None or idx <= header_index:
+            continue
+        cleaned = [clean_value(cell) for cell in row]
+        if not any(cleaned):
+            continue
+        try:
+            date_text = cleaned[headers.get("bokförd", 0)] if headers else cleaned[0]
+            if not date_text:
+                continue
+            occurred_at = parse_date(str(date_text))
+            if occurred_at is None:
+                raise ValueError("invalid date")
+            description = cleaned[headers.get("text", 2)] if headers else ""
+            if not description:
+                description = cleaned[headers.get("typ", 3)] if headers else ""
+            amount_raw = cleaned[headers.get("insättningar/uttag", 5)] if headers else ""
+            amount = parse_decimal_value(amount_raw)
+            if amount is None:
+                raise ValueError("invalid amount")
+            rows.append(
+                {
+                    "date": occurred_at.isoformat(),
+                    "description": str(description),
+                    "amount": str(amount),
+                }
+            )
+        except (ValueError, TypeError, IndexError) as exc:  # pragma: no cover - defensive
+            errors.append((idx, f"Unable to parse row: {exc}"))
+
+    if header_index is None:
+        errors.append((0, "SEB export is missing the expected headers"))
+
+    return rows, errors
+
+
+__all__ = ["parse_seb"]

--- a/apps/api/services/imports/parsers/swedbank.py
+++ b/apps/api/services/imports/parsers/swedbank.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Dict, List, Optional, Tuple
+
+from ..utils import clean_header, clean_value, parse_decimal_value
+from .types import NormalizedRow, ParseResult
+
+
+def parse_swedbank(
+    sheet,
+    *,
+    parse_date: Callable[[str], Optional[datetime]],
+) -> ParseResult:
+    """Parse Swedbank statement exports."""
+
+    header_index = None
+    headers: Dict[str, int] = {}
+    rows: List[NormalizedRow] = []
+    errors: List[Tuple[int, str]] = []
+
+    for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+        header_map = {clean_header(val): pos for pos, val in enumerate(row) if val}
+        if not header_index and {"bokföringsdag", "belopp"}.issubset(header_map.keys()):
+            header_index = idx
+            headers = header_map
+            continue
+        if header_index is None or idx <= header_index:
+            continue
+        cleaned = [clean_value(cell) for cell in row]
+        if not any(cleaned):
+            continue
+        try:
+            date_text = cleaned[headers.get("bokföringsdag", 1)]
+            occurred_at = parse_date(str(date_text))
+            if occurred_at is None:
+                raise ValueError("invalid date")
+            ref = cleaned[headers.get("referens", 4)] if headers else ""
+            desc = cleaned[headers.get("beskrivning", 5)] if headers else ""
+            description = f"{ref} {desc}".strip() or desc or ref
+            amount_raw = cleaned[headers.get("belopp", 6)] if headers else ""
+            amount = parse_decimal_value(amount_raw)
+            if amount is None:
+                raise ValueError("invalid amount")
+            rows.append(
+                {
+                    "date": occurred_at.isoformat(),
+                    "description": description,
+                    "amount": str(amount),
+                }
+            )
+        except (ValueError, TypeError, IndexError) as exc:  # pragma: no cover - defensive
+            errors.append((idx, f"Unable to parse row: {exc}"))
+
+    if header_index is None:
+        errors.append((0, "Swedbank export is missing the expected headers"))
+
+    return rows, errors
+
+
+__all__ = ["parse_swedbank"]

--- a/apps/api/services/imports/parsers/types.py
+++ b/apps/api/services/imports/parsers/types.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+NormalizedRow = Dict[str, Any]
+ParseResult = Tuple[List[NormalizedRow], List[Tuple[int, str]]]
+
+__all__ = ["NormalizedRow", "ParseResult"]

--- a/apps/api/services/imports/suggestions.py
+++ b/apps/api/services/imports/suggestions.py
@@ -1,0 +1,221 @@
+"""Suggestion helpers for import previews."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, Optional
+from uuid import UUID
+
+from ...models import Subscription
+from .utils import parse_iso_date, safe_decimal
+
+
+@dataclass
+class CategorySuggestion:
+    category_id: UUID | None
+    category: Optional[str]
+    confidence: float
+    reason: Optional[str] = None
+
+
+@dataclass
+class SubscriptionSuggestion:
+    subscription_id: UUID
+    subscription_name: str
+    confidence: float
+    reason: Optional[str] = None
+
+
+@dataclass
+class RuleMatch:
+    rule_id: UUID
+    category_id: Optional[UUID]
+    category_name: Optional[str]
+    subscription_id: Optional[UUID]
+    subscription_name: Optional[str]
+    summary: str
+    score: float
+    rule_type: str
+
+
+SUBSCRIPTION_SUGGESTION_THRESHOLD = 0.8
+
+
+def suggest_categories(
+    rows: list[dict],
+    column_map: Dict[str, str],
+    rule_matches: Optional[Dict[int, RuleMatch]] = None,
+) -> Dict[int, CategorySuggestion]:
+    if not column_map or not column_map.get("description") or not column_map.get("amount"):
+        return {}
+    heuristic: Dict[int, CategorySuggestion] = {}
+    locked: set[int] = set()
+    if rule_matches:
+        for idx, match in rule_matches.items():
+            if match.category_name:
+                heuristic[idx] = CategorySuggestion(
+                    category_id=match.category_id,
+                    category=match.category_name,
+                    confidence=0.95,
+                    reason=match.summary or "Rule match",
+                )
+                locked.add(idx)
+
+    for idx, row in enumerate(rows):
+        if idx in locked:
+            continue
+        heuristic[idx] = suggest_category_heuristic(row, column_map)
+
+    return heuristic
+
+
+def suggest_category_heuristic(row: dict, column_map: Dict[str, str]) -> CategorySuggestion:
+    description = str(row.get(column_map["description"], ""))
+    amount_text = str(row.get(column_map["amount"], ""))
+
+    normalized_desc = description.lower()
+    keyword_map = {
+        "rent": "Rent",
+        "salary": "Salary",
+        "payroll": "Salary",
+        "grocery": "Groceries",
+        "market": "Groceries",
+        "uber": "Transport",
+        "lyft": "Transport",
+        "electric": "Utilities",
+        "water": "Utilities",
+        "internet": "Utilities",
+    }
+    for keyword, category in keyword_map.items():
+        if keyword in normalized_desc:
+            return CategorySuggestion(category_id=None, category=category, confidence=0.65)
+
+    return CategorySuggestion(
+        category_id=None,
+        category=None,
+        confidence=0.3,
+        reason=f"No signal for {amount_text}",
+    )
+
+
+def suggest_subscriptions(
+    rows: list[dict],
+    column_map: Dict[str, str],
+    subscriptions: list[Subscription],
+    last_amounts: dict[UUID, Decimal],
+    rule_matches: Optional[Dict[int, RuleMatch]] = None,
+) -> Dict[int, SubscriptionSuggestion]:
+    if not rows:
+        return {}
+    description_header = column_map.get("description")
+    amount_header = column_map.get("amount")
+    date_header = column_map.get("date")
+    if not description_header:
+        return {}
+
+    if not subscriptions:
+        return {}
+
+    suggestions: Dict[int, SubscriptionSuggestion] = {}
+    locked: set[int] = set()
+    if rule_matches:
+        for idx, match in rule_matches.items():
+            if match.subscription_id:
+                suggestions[idx] = SubscriptionSuggestion(
+                    subscription_id=match.subscription_id,
+                    subscription_name=match.subscription_name or "Matched rule",
+                    confidence=0.99,
+                    reason=match.summary or "Rule match",
+                )
+                locked.add(idx)
+    for idx, row in enumerate(rows):
+        if idx in locked:
+            continue
+        description = str(row.get(description_header, "") or "")
+        amount = safe_decimal(row.get(amount_header)) if amount_header else None
+        occurred_at = parse_iso_date(str(row.get(date_header, ""))) if date_header else None
+
+        best: SubscriptionSuggestion | None = None
+        for subscription in subscriptions:
+            candidate = _score_subscription(
+                subscription,
+                description,
+                amount,
+                occurred_at,
+                last_amounts.get(subscription.id),
+            )
+            if candidate is None:
+                continue
+            if best is None or candidate.confidence > best.confidence:
+                best = candidate
+        if best and best.confidence >= SUBSCRIPTION_SUGGESTION_THRESHOLD:
+            suggestions[idx] = best
+    return suggestions
+
+
+def _score_subscription(  # pylint: disable=too-many-positional-arguments
+    subscription: Subscription,
+    description: str,
+    amount: Optional[Decimal],
+    occurred_at: Optional[datetime],
+    last_amount: Optional[Decimal],
+) -> Optional[SubscriptionSuggestion]:
+    text_match, text_reason = _match_subscription_text(subscription.matcher_text, description)
+    if not text_match:
+        return None
+
+    confidence = 0.82 if text_reason == "regex" else 0.8
+    reasons = [f"{text_reason} match"]
+
+    if subscription.matcher_day_of_month and occurred_at:
+        if occurred_at.day == subscription.matcher_day_of_month:
+            confidence += 0.1
+            reasons.append("day-of-month aligns")
+        else:
+            confidence -= 0.05
+
+    if subscription.matcher_amount_tolerance is not None and amount is not None:
+        if last_amount is not None:
+            delta = (abs(amount) - abs(last_amount)).copy_abs()
+            if delta <= subscription.matcher_amount_tolerance:
+                confidence += 0.08
+                reasons.append("amount within tolerance of last charge")
+            else:
+                return None
+        else:
+            reasons.append("tolerance provided but no history; skipping amount check")
+
+    confidence = min(confidence, 0.98)
+
+    return SubscriptionSuggestion(
+        subscription_id=subscription.id,
+        subscription_name=subscription.name,
+        confidence=confidence,
+        reason="; ".join(reasons),
+    )
+
+
+def _match_subscription_text(pattern: str, description: str) -> tuple[bool, str]:
+    normalized = description.lower()
+    try:
+        if re.search(pattern, description, flags=re.IGNORECASE):
+            return True, "regex"
+    except re.error:
+        pass
+    if pattern.lower() in normalized:
+        return True, "substring"
+    return False, ""
+
+
+__all__ = [
+    "CategorySuggestion",
+    "RuleMatch",
+    "SUBSCRIPTION_SUGGESTION_THRESHOLD",
+    "SubscriptionSuggestion",
+    "suggest_categories",
+    "suggest_category_heuristic",
+    "suggest_subscriptions",
+]

--- a/apps/api/services/imports/transfers.py
+++ b/apps/api/services/imports/transfers.py
@@ -1,0 +1,59 @@
+"""Transfer matching helper for import previews."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, List
+
+from .utils import parse_iso_date
+
+
+def match_transfers(
+    rows: List[dict[str, Any]], column_map: Dict[str, str]
+) -> Dict[int, dict[str, Any]]:
+    if not rows:
+        return {}
+
+    amount_header = column_map.get("amount")
+    date_header = column_map.get("date")
+    if not amount_header:
+        return {}
+
+    entries: List[Dict[str, Any]] = []
+    for idx, row in enumerate(rows):
+        try:
+            amount = Decimal(str(row.get(amount_header, "")))
+        except (ArithmeticError, InvalidOperation, TypeError, ValueError):
+            continue
+        date_value = parse_iso_date(str(row.get(date_header, ""))) if date_header else None
+        entries.append({"idx": idx, "amount": amount, "date": date_value})
+
+    matches: Dict[int, dict[str, Any]] = {}
+    used: set[int] = set()
+    for entry in entries:
+        if entry["idx"] in used:
+            continue
+        for other in entries:
+            if other["idx"] in used or other["idx"] == entry["idx"]:
+                continue
+            if (entry["amount"] + other["amount"]) != 0:
+                continue
+            if entry["date"] and other["date"]:
+                delta = abs((entry["date"] - other["date"]).days)
+                if delta > 2:
+                    continue
+            match_payload = {
+                "paired_with": other["idx"] + 1,
+                "reason": "Matched transfer by amount and date proximity",
+            }
+            matches[entry["idx"]] = match_payload
+            matches[other["idx"]] = {
+                "paired_with": entry["idx"] + 1,
+                "reason": "Matched transfer by amount and date proximity",
+            }
+            used.update({entry["idx"], other["idx"]})
+            break
+    return matches
+
+
+__all__ = ["match_transfers"]

--- a/apps/api/services/imports/utils.py
+++ b/apps/api/services/imports/utils.py
@@ -1,0 +1,97 @@
+"""Shared helpers for import parsing and normalization."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional
+
+
+def parse_iso_date(value: str) -> Optional[datetime]:
+    """Parse an ISO-like date string into a naive datetime (UTC assumed)."""
+
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    except ValueError:
+        return None
+
+
+def clean_header(header: object) -> str:
+    return str(header).strip().lower().replace(" ", "_") if header is not None else ""
+
+
+def clean_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (int, float, Decimal)):
+        return str(value)
+    return str(value).strip()
+
+
+def parse_decimal_value(value: object) -> Optional[Decimal]:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    text = str(value).strip()
+    if not text:
+        return None
+    cleaned = text.replace("\u2212", "-").replace("−", "-").replace("\xa0", "").replace(" ", "")
+    match = re.search(r"-?[\d.,]+", cleaned)
+    if not match:
+        return None
+    numeric = match.group(0)
+    if "," in numeric and "." in numeric:
+        if numeric.rfind(",") > numeric.rfind("."):
+            numeric = numeric.replace(".", "")
+            numeric = numeric.replace(",", ".")
+        else:
+            numeric = numeric.replace(",", "")
+    else:
+        numeric = numeric.replace(",", ".")
+    try:
+        return Decimal(numeric)
+    except (ArithmeticError, InvalidOperation, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def is_decimal(value: str) -> bool:
+    try:
+        Decimal(str(value))
+    except (ArithmeticError, InvalidOperation, TypeError, ValueError):
+        return False
+    return True
+
+
+def safe_decimal(value: Any) -> Optional[Decimal]:
+    try:
+        return Decimal(str(value))
+    except (ArithmeticError, InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def is_date_like(value: str) -> bool:
+    if not value:
+        return False
+    text = str(value)
+    try:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+__all__ = [
+    "clean_header",
+    "clean_value",
+    "is_date_like",
+    "is_decimal",
+    "parse_decimal_value",
+    "parse_iso_date",
+    "safe_decimal",
+]

--- a/apps/api/tests/test_import_helpers.py
+++ b/apps/api/tests/test_import_helpers.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import io
+from decimal import Decimal
+from uuid import uuid4
+
+from openpyxl import Workbook
+
+from apps.api.models import Subscription
+from apps.api.services.imports.parsers import parse_bank_rows
+from apps.api.services.imports.suggestions import (
+    RuleMatch,
+    suggest_categories,
+    suggest_category_heuristic,
+    suggest_subscriptions,
+)
+from apps.api.services.imports.transfers import match_transfers
+from apps.api.shared import BankImportType
+
+
+def _workbook_bytes(builder) -> bytes:
+    workbook = Workbook()
+    sheet = workbook.active
+    builder(sheet)
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()
+
+
+def test_parse_bank_rows_requires_supported_extension():
+    rows, errors = parse_bank_rows(
+        filename="transactions.csv", content=b"not-used", bank_type=BankImportType.SWEDBANK
+    )
+    assert not rows
+    assert errors and "unsupported file type" in errors[0][1].lower()
+
+
+def test_parse_bank_rows_reports_missing_headers():
+    content = _workbook_bytes(lambda sheet: sheet.append(["Only", "Two", "Columns"]))
+    rows, errors = parse_bank_rows(
+        filename="swedbank.xlsx",
+        content=content,
+        bank_type=BankImportType.SWEDBANK,
+    )
+    assert not rows
+    assert any("missing" in message.lower() for _, message in errors)
+
+
+def test_parse_circle_k_adds_location_and_negates_amounts():
+    def build(sheet):
+        sheet.append(["Transaktionsexport"])
+        sheet.append([])
+        sheet.append(
+            ["Datum", "Bokfört", "Specifikation", "Ort", "Valuta", "Utl. belopp", "Belopp"]
+        )
+        sheet.append(["2024-02-01", "2024-02-02", "Groceries", "Stockholm", "SEK", "", "250"])
+
+    rows, errors = parse_bank_rows(
+        filename="circle.xlsx",
+        content=_workbook_bytes(build),
+        bank_type=BankImportType.CIRCLE_K_MASTERCARD,
+    )
+    assert not errors
+    assert rows
+    first = rows[0]
+    assert "stockholm" in first["description"].lower()
+    assert Decimal(first["amount"]) < 0
+
+
+def test_category_suggestion_prefers_rule_match():
+    rows = [{"description": "Rent for apartment", "amount": "1200"}]
+    column_map = {"description": "description", "amount": "amount"}
+    rule = RuleMatch(
+        rule_id=uuid4(),
+        category_id=uuid4(),
+        category_name="Rent",
+        subscription_id=None,
+        subscription_name=None,
+        summary="matched rent keyword",
+        score=0.9,
+        rule_type="category",
+    )
+
+    suggestions = suggest_categories(rows, column_map, {0: rule})
+    assert suggestions[0].category == "Rent"
+    assert suggestions[0].reason == "matched rent keyword"
+
+
+def test_category_heuristic_maps_keywords():
+    column_map = {"description": "description", "amount": "amount"}
+    suggestion = suggest_category_heuristic(
+        {"description": "Uber trip downtown", "amount": "-22.00"},
+        column_map,
+    )
+    assert suggestion.category == "Transport"
+    assert suggestion.confidence == 0.65
+
+
+def test_suggest_subscriptions_uses_amount_tolerance():
+    subscription = Subscription(
+        name="Spotify",
+        matcher_text="spotify",
+        matcher_amount_tolerance=Decimal("1.00"),
+        matcher_day_of_month=1,
+    )
+    rows = [{"description": "Spotify AB", "amount": "99.00", "date": "2024-03-01"}]
+    column_map = {"description": "description", "amount": "amount", "date": "date"}
+
+    suggestions = suggest_subscriptions(
+        rows, column_map, [subscription], {subscription.id: Decimal("99.50")}
+    )
+    assert 0 in suggestions
+    assert suggestions[0].subscription_name == "Spotify"
+
+    high_delta_rows = [{"description": "Spotify AB", "amount": "120.00", "date": "2024-03-01"}]
+    no_match = suggest_subscriptions(
+        high_delta_rows, column_map, [subscription], {subscription.id: Decimal("99.50")}
+    )
+    assert not no_match
+
+
+def test_suggest_subscriptions_respects_rule_lock():
+    subscription = Subscription(
+        name="Gym",
+        matcher_text="gym",
+        matcher_amount_tolerance=None,
+        matcher_day_of_month=None,
+    )
+    column_map = {"description": "description", "amount": "amount", "date": "date"}
+    rows = [{"description": "Gym monthly", "amount": "50.00", "date": "2024-02-01"}]
+    rule = RuleMatch(
+        rule_id=uuid4(),
+        category_id=None,
+        category_name=None,
+        subscription_id=subscription.id,
+        subscription_name="Gym",
+        summary="rule hit",
+        score=0.99,
+        rule_type="subscription",
+    )
+
+    suggestions = suggest_subscriptions(rows, column_map, [subscription], {}, {0: rule})
+    assert suggestions[0].subscription_id == subscription.id
+    assert suggestions[0].reason == "rule hit"
+
+
+def test_match_transfers_pairs_opposite_amounts_and_dates():
+    rows = [
+        {"amount": "100.00", "date": "2024-01-02"},
+        {"amount": "-100.00", "date": "2024-01-01"},
+    ]
+    matches = match_transfers(rows, {"amount": "amount", "date": "date"})
+    assert matches[0]["paired_with"] == 2
+    assert matches[1]["paired_with"] == 1
+
+
+def test_match_transfers_ignores_far_apart_dates():
+    rows = [
+        {"amount": "50.00", "date": "2024-01-01"},
+        {"amount": "-50.00", "date": "2024-01-10"},
+    ]
+    matches = match_transfers(rows, {"amount": "amount", "date": "date"})
+    assert not matches


### PR DESCRIPTION
## Summary
- refactor the import service into a package that delegates bank statement parsing to dedicated parser strategies and shared utilities
- move category/subscription suggestion and transfer matching logic into standalone helpers used by preview_import
- add focused pytest coverage for the parser, suggestion, and transfer helpers

## Testing
- make type-check
- PYTHONPATH=. pytest apps/api/tests/test_import_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945cae259f4832d8dd7493bddefce4c)