### PR TITLE
Add monthly database backups to S3

### DIFF
--- a/apps/api/handlers/backups.py
+++ b/apps/api/handlers/backups.py
@@ -1,0 +1,39 @@
+"""Scheduled handler to export database snapshots to S3."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from ..jobs.database_backup import DatabaseBackupJob
+from .utils import ensure_engine
+
+logger = logging.getLogger(__name__)
+
+
+def run_database_backup(_event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
+    """Entrypoint for the monthly backup EventBridge rule."""
+
+    ensure_engine()
+    bucket = os.getenv("BACKUP_BUCKET_NAME")
+    prefix = os.getenv("BACKUP_PREFIX", "database-backups")
+
+    if not bucket:
+        logger.error("BACKUP_BUCKET_NAME is not configured; aborting backup run.")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": "BACKUP_BUCKET_NAME is not configured"}),
+        }
+
+    job = DatabaseBackupJob(bucket=bucket, prefix=prefix)
+    result = job.run()
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(result),
+    }
+
+
+__all__ = ["run_database_backup"]

--- a/apps/api/jobs/__init__.py
+++ b/apps/api/jobs/__init__.py
@@ -1,5 +1,6 @@
 """Background job modules for Finance Tracker."""
 
+from .database_backup import DatabaseBackupJob
 from .loan_interest import accrue_interest
 
-__all__ = ["accrue_interest"]
+__all__ = ["accrue_interest", "DatabaseBackupJob"]

--- a/apps/api/jobs/database_backup.py
+++ b/apps/api/jobs/database_backup.py
@@ -1,0 +1,115 @@
+"""Database backup helpers for scheduled exports."""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, Dict, List
+from uuid import UUID
+
+import boto3
+from sqlalchemy import select
+from sqlalchemy.sql.schema import Table
+from sqlmodel import Session, SQLModel
+
+from .. import models as _models  # noqa: F401
+from ..shared.session import get_session
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, enum.Enum):
+        return value.value
+    return value
+
+
+class DatabaseBackupJob:
+    """Export relational tables to JSON and persist them to S3."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str,
+        s3_client=None,
+        now: datetime | None = None,
+    ) -> None:
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self.now = now or datetime.now(timezone.utc)
+        self._s3 = s3_client or boto3.client("s3")
+
+    @property
+    def base_prefix(self) -> str:
+        dated_prefix = self.now.strftime("%Y/%m")
+        run_prefix = self.now.strftime("%Y-%m-%dT%H-%M-%SZ")
+        parts = [self.prefix, dated_prefix, run_prefix]
+        return "/".join(part for part in parts if part)
+
+    def run(self) -> Dict[str, Any]:
+        """Backup every mapped SQLModel table into the configured S3 bucket."""
+
+        session = get_session()
+        manifest: List[Dict[str, Any]] = []
+
+        try:
+            for table in SQLModel.metadata.sorted_tables:
+                key = self._table_key(table.name)
+                rows = self._fetch_table_rows(session, table)
+                self._upload_json(key, rows)
+
+                entry = {
+                    "table": table.name,
+                    "row_count": len(rows),
+                    "s3_key": key,
+                }
+                logger.info("Backed up table %s to %s (%s rows)", table.name, key, len(rows))
+                manifest.append(entry)
+
+            manifest_key = f"{self.base_prefix}/manifest.json"
+            manifest_payload = {
+                "generated_at": self.now.isoformat(),
+                "tables": manifest,
+            }
+            self._upload_json(manifest_key, manifest_payload)
+
+            return {
+                "bucket": self.bucket,
+                "manifest_key": manifest_key,
+                "tables": manifest,
+            }
+        finally:
+            session.close()
+
+    def _fetch_table_rows(self, session: Session, table: Table) -> List[Dict[str, Any]]:
+        result = session.execute(select(table)).mappings()
+        rows: List[Dict[str, Any]] = []
+        for mapping in result:
+            rows.append({key: _normalize_value(value) for key, value in dict(mapping).items()})
+
+        return rows
+
+    def _upload_json(self, key: str, payload: Any) -> None:
+        body = json.dumps(payload, default=_normalize_value).encode("utf-8")
+        self._s3.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+
+    def _table_key(self, table_name: str) -> str:
+        return f"{self.base_prefix}/{table_name}.json"
+
+
+__all__ = ["DatabaseBackupJob"]

--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -56,6 +56,14 @@ provider:
             - execute-api:ManageConnections
           Resource:
             - Fn::Sub: "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebsocketsApi}/*"
+        - Effect: Allow
+          Action:
+            - s3:PutObject
+            - s3:AbortMultipartUpload
+            - s3:ListBucket
+          Resource:
+            - arn:aws:s3:::${ssm:/finance-tracker/${self:provider.stage}/backups/bucket}
+            - arn:aws:s3:::${ssm:/finance-tracker/${self:provider.stage}/backups/bucket}/*
   httpApi:
     name: ${self:service}-${self:provider.stage}-http
     cors: true
@@ -82,6 +90,21 @@ custom:
   backendLayerArn: ${cf:finance-tracker-layer-service-${self:provider.stage}.BackendDepsLambdaLayerQualifiedArn}
 
 functions:
+  databaseBackup:
+    handler: apps/api/handlers/backups.run_database_backup
+    timeout: 900
+    memorySize: 1024
+    layers:
+      - ${self:custom.backendLayerArn}
+    environment:
+      BACKUP_BUCKET_NAME: ${ssm:/finance-tracker/${self:provider.stage}/backups/bucket}
+      BACKUP_PREFIX: finance-tracker/${self:provider.stage}/database-backups
+    events:
+      - schedule:
+          rate: cron(0 3 1 * ? *)
+          enabled: true
+          description: Monthly export of database tables to S3
+
   warmDatabase:
     handler: apps/api/handlers/warmup.warm_database
     timeout: 12

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -59,3 +59,10 @@ output "api_domain_configuration" {
     certificate_parameter_arn = module.resources.api_domain_certificate_parameter_name
   }
 }
+
+output "backup_parameter_paths" {
+  description = "SSM parameter names containing backup storage configuration."
+  value = {
+    bucket = module.resources.backup_bucket_parameter_name
+  }
+}

--- a/infra/terraform/resources/backups.tf
+++ b/infra/terraform/resources/backups.tf
@@ -1,0 +1,102 @@
+locals {
+  backup_parameter_prefix = "/finance-tracker/${var.environment}/backups"
+  backup_bucket_name      = "${local.name_prefix}-${var.account_id}-database-backups"
+}
+
+resource "aws_s3_bucket" "database_backups" {
+  bucket        = local.backup_bucket_name
+  force_destroy = false
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-database-backups"
+    },
+  )
+}
+
+resource "aws_s3_bucket_versioning" "database_backups" {
+  bucket = aws_s3_bucket.database_backups.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "database_backups" {
+  bucket = aws_s3_bucket.database_backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "database_backups" {
+  bucket = aws_s3_bucket.database_backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "database_backups" {
+  bucket = aws_s3_bucket.database_backups.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "database_backups" {
+  bucket = aws_s3_bucket.database_backups.id
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "database_backups" {
+  bucket = aws_s3_bucket.database_backups.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.database_backups.arn,
+          "${aws_s3_bucket.database_backups.arn}/*",
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = false }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_ssm_parameter" "database_backup_bucket" {
+  name        = "${local.backup_parameter_prefix}/bucket"
+  description = "S3 bucket used to store monthly Finance Tracker database backups."
+  type        = "String"
+  value       = aws_s3_bucket.database_backups.bucket
+  overwrite   = true
+
+  tags = local.common_tags
+}
+
+output "backup_bucket_parameter_name" {
+  description = "SSM parameter exposing the backup bucket name."
+  value       = aws_ssm_parameter.database_backup_bucket.name
+}

--- a/infra/terraform/resources/vpc_endpoints.tf
+++ b/infra/terraform/resources/vpc_endpoints.tf
@@ -1,0 +1,35 @@
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "s3_gateway" {
+  vpc_id            = aws_vpc.finance_tracker.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_default_route_table.finance_tracker.id]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowBackupsBucketAccess"
+        Effect = "Allow"
+        Principal = "*"
+        Action = [
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          aws_s3_bucket.database_backups.arn,
+          "${aws_s3_bucket.database_backups.arn}/*",
+        ]
+      }
+    ]
+  })
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-s3-gateway"
+    },
+  )
+}


### PR DESCRIPTION
## Summary
- add an encrypted S3 bucket and parameter wiring for monthly database backups
- introduce a scheduled Lambda that exports all SQLModel tables to JSON and uploads a manifest to S3
- expose the new backup configuration outputs and wire the function into the shared IAM role

## Testing
- make format
- make type-check
- terraform fmt (fails: terraform CLI not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470aac31d0832d972dfc938fea926f)