### PR TITLE
Limit reconcile to normal accounts and add investment balance snapshot/update flow

### DIFF
--- a/apps/api/handlers/investments.py
+++ b/apps/api/handlers/investments.py
@@ -5,18 +5,24 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+from pydantic import ValidationError
+
+from ..models import Account, InvestmentSnapshot
 from ..schemas import (
     InvestmentOverviewResponse,
+    InvestmentSnapshotCreateRequest,
+    InvestmentSnapshotCreateResponse,
     InvestmentTransactionListResponse,
     InvestmentTransactionRead,
 )
 from ..services import InvestmentSnapshotService
-from ..shared import session_scope
+from ..shared import AccountType, session_scope
 from .utils import (
     ensure_engine,
     get_query_params,
     get_user_id,
     json_response,
+    parse_body,
     reset_engine_state,
 )
 
@@ -68,8 +74,52 @@ def investment_overview(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     return json_response(200, response)
 
 
+def create_investment_snapshot(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
+    """HTTP POST /investments/snapshots."""
+
+    ensure_engine()
+    user_id = get_user_id(event)
+    payload = parse_body(event)
+
+    try:
+        data = InvestmentSnapshotCreateRequest.model_validate(payload)
+    except ValidationError as exc:
+        return json_response(400, {"error": exc.errors()})
+
+    with session_scope(user_id=user_id) as session:
+        account = session.get(Account, data.account_id)
+        if account is None or account.account_type != AccountType.INVESTMENT:
+            return json_response(404, {"error": "Investment account not found"})
+
+        parsed_payload = {"accounts": {account.name: float(data.balance)}}
+        snapshot = InvestmentSnapshot(
+            user_id=user_id,
+            provider="manual",
+            report_type="balance_update",
+            account_name=account.name,
+            snapshot_date=data.snapshot_date,
+            portfolio_value=data.balance,
+            raw_text=data.notes or "Manual investment balance update",
+            parsed_payload=parsed_payload,
+            cleaned_payload=None,
+            bedrock_metadata=None,
+        )
+        session.add(snapshot)
+        session.commit()
+        session.refresh(snapshot)
+
+    response = InvestmentSnapshotCreateResponse(
+        snapshot_id=snapshot.id,
+        account_id=data.account_id,
+        snapshot_date=data.snapshot_date,
+        balance=data.balance,
+    )
+    return json_response(201, response.model_dump(mode="json"))
+
+
 __all__ = [
     "list_investment_transactions",
     "reset_handler_state",
     "investment_overview",
+    "create_investment_snapshot",
 ]

--- a/apps/api/schemas/__init__.py
+++ b/apps/api/schemas/__init__.py
@@ -64,6 +64,8 @@ from .investments import (
     InvestmentGrowthRead,
     InvestmentOverviewResponse,
     InvestmentPortfolioOverviewRead,
+    InvestmentSnapshotCreateRequest,
+    InvestmentSnapshotCreateResponse,
     InvestmentTransactionListResponse,
     InvestmentTransactionRead,
     InvestmentValuePointRead,
@@ -257,4 +259,6 @@ __all__ = [
     "TaxTotalSummaryResponse",
     "TaxSummaryQuery",
     "TaxSummaryResponse",
+    "InvestmentSnapshotCreateRequest",
+    "InvestmentSnapshotCreateResponse",
 ]

--- a/apps/api/schemas/investments.py
+++ b/apps/api/schemas/investments.py
@@ -128,6 +128,24 @@ class InvestmentOverviewResponse(BaseModel):
     recent_cashflows: list[InvestmentCashflowEventRead] = Field(default_factory=list)
 
 
+class InvestmentSnapshotCreateRequest(BaseModel):
+    """Request to create a manual investment snapshot."""
+
+    account_id: UUID
+    snapshot_date: date
+    balance: Decimal
+    notes: Optional[str] = None
+
+
+class InvestmentSnapshotCreateResponse(BaseModel):
+    """Response after creating a manual investment snapshot."""
+
+    snapshot_id: UUID
+    account_id: UUID
+    snapshot_date: date
+    balance: Decimal
+
+
 __all__ = [
     "InvestmentTransactionRead",
     "InvestmentTransactionListResponse",
@@ -139,4 +157,6 @@ __all__ = [
     "InvestmentAccountOverviewRead",
     "InvestmentCashflowEventRead",
     "InvestmentOverviewResponse",
+    "InvestmentSnapshotCreateRequest",
+    "InvestmentSnapshotCreateResponse",
 ]

--- a/apps/web/src/features/investments/investmentsSlice.ts
+++ b/apps/web/src/features/investments/investmentsSlice.ts
@@ -8,13 +8,16 @@ export interface InvestmentsState {
   transactions: InvestmentTransactionRead[];
   overview?: InvestmentOverviewResponse;
   loading: boolean;
+  updateLoading: boolean;
   error?: string;
+  updateError?: string;
 }
 
 const initialState: InvestmentsState = {
   transactions: [],
   overview: undefined,
   loading: false,
+  updateLoading: false,
 };
 
 const investmentsSlice = createSlice({
@@ -35,6 +38,16 @@ const investmentsSlice = createSlice({
     setInvestmentsError(state, action: PayloadAction<string | undefined>) {
       state.error = action.payload ?? "Unable to load investment data.";
     },
+    setInvestmentsUpdateLoading(state, action: PayloadAction<boolean>) {
+      state.updateLoading = action.payload;
+    },
+    setInvestmentsUpdateError(
+      state,
+      action: PayloadAction<string | undefined>,
+    ) {
+      state.updateError =
+        action.payload ?? "Unable to update investment balance.";
+    },
   },
   selectors: {
     selectInvestmentsState: (state) => state,
@@ -42,6 +55,8 @@ const investmentsSlice = createSlice({
     selectInvestmentOverview: (state) => state.overview,
     selectInvestmentsLoading: (state) => state.loading,
     selectInvestmentsError: (state) => state.error,
+    selectInvestmentsUpdateLoading: (state) => state.updateLoading,
+    selectInvestmentsUpdateError: (state) => state.updateError,
   },
 });
 
@@ -50,6 +65,8 @@ export const {
   setOverview,
   setInvestmentsLoading,
   setInvestmentsError,
+  setInvestmentsUpdateLoading,
+  setInvestmentsUpdateError,
 } = investmentsSlice.actions;
 
 export const {
@@ -58,5 +75,7 @@ export const {
   selectInvestmentOverview,
   selectInvestmentsLoading,
   selectInvestmentsError,
+  selectInvestmentsUpdateLoading,
+  selectInvestmentsUpdateError,
 } = investmentsSlice.selectors;
 export const InvestmentsReducer = investmentsSlice.reducer;

--- a/apps/web/src/hooks/use-api.ts
+++ b/apps/web/src/hooks/use-api.ts
@@ -60,6 +60,7 @@ import {
 import {
   FetchInvestmentTransactions,
   FetchInvestmentOverview,
+  CreateInvestmentSnapshot,
 } from "@/features/investments/investmentsSaga";
 import {
   selectInvestmentsState,
@@ -317,12 +318,19 @@ export const useInvestmentsApi = () => {
     [dispatch],
   );
 
+  const createSnapshot = useCallback(
+    (data: Parameters<typeof CreateInvestmentSnapshot>[0]["data"]) =>
+      dispatch(CreateInvestmentSnapshot({ data })),
+    [dispatch],
+  );
+
   return {
     ...state,
     transactions,
     overview,
     fetchTransactions,
     fetchOverview,
+    createSnapshot,
   };
 };
 

--- a/apps/web/src/pages/transactions/transactions.tsx
+++ b/apps/web/src/pages/transactions/transactions.tsx
@@ -50,6 +50,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   TransactionType,
+  AccountType,
   type CategoryRead,
   type TransactionRead,
 } from "@/types/api";
@@ -217,13 +218,17 @@ export const Transactions: React.FC = () => {
   >(null);
   const [detailsId, setDetailsId] = useState<string | null>(null);
   const [reconcileOpen, setReconcileOpen] = useState(false);
-  const needsReconcile = useMemo(
-    () => accounts.some((acc) => acc.needs_reconciliation),
+  const reconcileEligibleAccounts = useMemo(
+    () => accounts.filter((acc) => acc.account_type === AccountType.NORMAL),
     [accounts],
   );
+  const needsReconcile = useMemo(
+    () => reconcileEligibleAccounts.some((acc) => acc.needs_reconciliation),
+    [reconcileEligibleAccounts],
+  );
   const reconcileTargets = useMemo(
-    () => accounts.filter((acc) => acc.needs_reconciliation),
-    [accounts],
+    () => reconcileEligibleAccounts.filter((acc) => acc.needs_reconciliation),
+    [reconcileEligibleAccounts],
   );
 
   useEffect(() => {

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -55,6 +55,8 @@ export type {
   InvestmentCashflowSummary,
   InvestmentGrowth,
   InvestmentValuePoint,
+  InvestmentSnapshotCreateRequest,
+  InvestmentSnapshotCreateResponse,
   InvestmentSnapshot,
   InvestmentTransactionListResponse,
   InvestmentTransactionRead,

--- a/apps/web/src/types/schemas.ts
+++ b/apps/web/src/types/schemas.ts
@@ -1201,6 +1201,20 @@ export const investmentOverviewResponseSchema = z.object({
   recent_cashflows: z.array(investmentCashflowEventSchema).default([]),
 });
 
+export const investmentSnapshotCreateRequestSchema = z.object({
+  account_id: z.string(),
+  snapshot_date: dateString,
+  balance: money,
+  notes: nullableString,
+});
+
+export const investmentSnapshotCreateResponseSchema = z.object({
+  snapshot_id: z.string(),
+  account_id: z.string(),
+  snapshot_date: dateString,
+  balance: money,
+});
+
 export const goalSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -1442,6 +1456,12 @@ export type InvestmentCashflowEvent = z.infer<
 >;
 export type InvestmentOverviewResponse = z.infer<
   typeof investmentOverviewResponseSchema
+>;
+export type InvestmentSnapshotCreateRequest = z.infer<
+  typeof investmentSnapshotCreateRequestSchema
+>;
+export type InvestmentSnapshotCreateResponse = z.infer<
+  typeof investmentSnapshotCreateResponseSchema
 >;
 export type GoalRead = z.infer<typeof goalSchema>;
 export type GoalListResponse = z.infer<typeof goalListSchema>;

--- a/infra/serverless/serverless.yml
+++ b/infra/serverless/serverless.yml
@@ -884,3 +884,15 @@ functions:
           path: /investments/overview
           method: GET
           authorizer: cognitoJwt
+
+  createInvestmentSnapshot:
+    handler: apps/api/handlers/investments.create_investment_snapshot
+    timeout: 29
+    memorySize: 512
+    layers:
+      - ${self:custom.backendLayerArn}
+    events:
+      - httpApi:
+          path: /investments/snapshots
+          method: POST
+          authorizer: cognitoJwt


### PR DESCRIPTION
### Motivation
- Prevent debt and investment accounts from appearing as reconciliation targets in the Transactions UI and only allow reconciliation for normal accounts.
- Allow users to record a manual investment statement balance so investment account valuations can be tracked via snapshots rather than ledger adjustments.

### Description
- Limit reconciliation scope in the Transactions UI by filtering accounts to `AccountType.NORMAL` in `apps/web/src/pages/transactions/transactions.tsx` and only show targets that need reconciliation among those accounts.
- Add a new backend handler `create_investment_snapshot` at `POST /investments/snapshots` implemented in `apps/api/handlers/investments.py`, plus request/response schemas `InvestmentSnapshotCreateRequest` and `InvestmentSnapshotCreateResponse` in `apps/api/schemas/investments.py` and export entries in `apps/api/schemas/__init__.py` and `infra/serverless/serverless.yml` route registration.
- Wire up frontend support: add Zod/TS client schemas (`investmentSnapshotCreateRequestSchema` / response) and API types, a new `createSnapshot` hook (`useInvestmentsApi`), saga action `CreateInvestmentSnapshot` and handler to call the new endpoint, and slice state (`updateLoading` / `updateError`) in `apps/web/src/features/investments`.
- Add an "Update balance" dialog to the Investments page that posts snapshots through the saga, with UI elements / validation and success/failure handling in `apps/web/src/pages/investments/investments.tsx`.

### Testing
- Ran frontend formatting and linting with `npm run format -w apps/web` and `npm run lint -w apps/web` which completed successfully after fixes. 
- Ran backend formatting and static checks with `make format` and `make type-check` which completed successfully (Black/isort/pyright/pylint/mypy checks passed). 
- Verified the development frontend launched (`npm run dev -w apps/web`) and exercised the Investments dialog manually (screenshot captured) to validate the UI flow and API wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b7597b894832db420d970c1bb236f)