### PR TITLE
Add cashflow volatility insights to reports

### DIFF
--- a/apps/web/src/pages/reports/components/cashflow-volatility-card.tsx
+++ b/apps/web/src/pages/reports/components/cashflow-volatility-card.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import type { CashflowVolatilitySummary } from "../reports-types";
+import { currency } from "../reports-utils";
+
+const formatCv = (cv: number | null) =>
+  cv === null ? "—" : `${(cv * 100).toFixed(1)}%`;
+
+const stabilityScoreClass = (score: number | null) => {
+  if (score === null) return "text-slate-900";
+  if (score >= 75) return "text-emerald-600";
+  if (score >= 50) return "text-amber-600";
+  return "text-rose-600";
+};
+
+const spikeBadgeStyles: Record<
+  CashflowVolatilitySummary["spikes"][number]["kind"],
+  string
+> = {
+  income: "bg-emerald-100 text-emerald-700",
+  expense: "bg-rose-100 text-rose-700",
+  net: "bg-indigo-100 text-indigo-700",
+};
+
+const spikeKindLabel: Record<
+  CashflowVolatilitySummary["spikes"][number]["kind"],
+  string
+> = {
+  income: "Income spike",
+  expense: "Expense spike",
+  net: "Net spike",
+};
+
+export const CashflowVolatilityCard: React.FC<{
+  title: string;
+  description: string;
+  loading: boolean;
+  volatility: CashflowVolatilitySummary | null;
+}> = ({ title, description, loading, volatility }) => {
+  return (
+    <Card className="h-full border-slate-200 shadow-[0_10px_40px_-20px_rgba(15,23,42,0.4)]">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-slate-900">
+          {title}
+        </CardTitle>
+        <p className="text-xs text-slate-500">{description}</p>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : !volatility ? (
+          <div className="flex h-52 items-center justify-center text-sm text-slate-600">
+            Monthly series unavailable.
+          </div>
+        ) : (
+          <div className="space-y-5">
+            <div className="flex items-end justify-between">
+              <div>
+                <p className="text-xs tracking-wide text-slate-500 uppercase">
+                  Stability score
+                </p>
+                <p
+                  className={`text-3xl font-semibold ${stabilityScoreClass(
+                    volatility.stabilityScore,
+                  )}`}
+                >
+                  {volatility.stabilityScore === null
+                    ? "—"
+                    : `${Math.round(volatility.stabilityScore)}%`}
+                </p>
+              </div>
+              <p className="text-xs text-slate-500">
+                Lower CVs raise the score.
+              </p>
+            </div>
+
+            <div className="space-y-2 text-sm">
+              <div className="grid grid-cols-[1fr_auto_auto] gap-2 text-[11px] text-slate-400 uppercase">
+                <span>Metric</span>
+                <span className="text-right">Std dev</span>
+                <span className="text-right">CV</span>
+              </div>
+              {[
+                { label: "Income", metric: volatility.income },
+                { label: "Expense", metric: volatility.expense },
+                { label: "Net", metric: volatility.net },
+              ].map((row) => (
+                <div
+                  key={row.label}
+                  className="grid grid-cols-[1fr_auto_auto] gap-2 text-slate-700"
+                >
+                  <span>{row.label}</span>
+                  <span className="text-right font-semibold text-slate-900">
+                    {currency(row.metric.stdDev)}
+                  </span>
+                  <span className="text-right text-slate-600">
+                    {formatCv(row.metric.cv)}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs tracking-wide text-slate-500 uppercase">
+                Spike months
+              </p>
+              {volatility.spikes.length ? (
+                <div className="flex flex-wrap gap-2">
+                  {volatility.spikes.map((spike) => (
+                    <Badge
+                      key={`${spike.date}-${spike.kind}`}
+                      className={spikeBadgeStyles[spike.kind]}
+                    >
+                      {spike.label} • {spikeKindLabel[spike.kind]}
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-slate-500">No months beyond 1.5σ.</p>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/pages/reports/hooks/use-total-analysis.ts
+++ b/apps/web/src/pages/reports/hooks/use-total-analysis.ts
@@ -2,6 +2,10 @@ import { useMemo } from "react";
 
 import type { TotalOverviewResponse } from "@/types/api";
 
+import type {
+  CashflowVolatilityMetric,
+  CashflowVolatilitySummary,
+} from "../reports-types";
 import { formatDate, monthLabel } from "../reports-utils";
 
 type TotalWindowPreset = "all" | "10" | "5" | "3";
@@ -62,6 +66,19 @@ const shouldUseProvidedCategoryColor = (
 function categoryAbsTotal(category: MixCategory) {
   return Math.abs(Number(category.total));
 }
+
+const volatilityStats = (values: number[]): CashflowVolatilityMetric => {
+  if (!values.length) {
+    return { mean: 0, stdDev: 0, cv: null };
+  }
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance =
+    values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
+  const stdDev = Math.sqrt(variance);
+  const meanAbs = Math.abs(mean);
+  const cv = meanAbs > 0 ? stdDev / meanAbs : null;
+  return { mean, stdDev, cv };
+};
 
 const buildComposition = (
   rows: MixYearRow[],
@@ -278,6 +295,92 @@ export const useTotalAnalysis = ({
       };
     });
   }, [totalOverview]);
+
+  const totalCashflowVolatility =
+    useMemo<CashflowVolatilitySummary | null>(() => {
+      if (!totalMonthlyIncomeExpense.length || !totalWindowRange) return null;
+      const series = totalMonthlyIncomeExpense
+        .filter(
+          (row) =>
+            row.date >= totalWindowRange.start &&
+            row.date <= totalWindowRange.end,
+        )
+        .map((row) => ({
+          date: row.date,
+          label: formatDate(row.date, { month: "short", year: "2-digit" }),
+          income: row.income,
+          expense: row.expense,
+          net: row.income - row.expense,
+        }));
+
+      if (!series.length) return null;
+
+      const incomeValues = series.map((row) => row.income);
+      const expenseValues = series.map((row) => row.expense);
+      const netValues = series.map((row) => row.net);
+
+      const income = volatilityStats(incomeValues);
+      const expense = volatilityStats(expenseValues);
+      const net = volatilityStats(netValues);
+
+      const cvValues = [income.cv, expense.cv, net.cv].filter(
+        (value): value is number =>
+          typeof value === "number" && !Number.isNaN(value),
+      );
+      const avgCv =
+        cvValues.length > 0
+          ? cvValues.reduce((sum, value) => sum + value, 0) / cvValues.length
+          : null;
+      const stabilityScore =
+        avgCv === null ? null : Math.max(0, 100 - Math.min(100, avgCv * 100));
+
+      const spikeThreshold = 1.5;
+      const spikes = series
+        .map((row) => {
+          const incomeZ =
+            income.stdDev > 0 ? (row.income - income.mean) / income.stdDev : 0;
+          const expenseZ =
+            expense.stdDev > 0
+              ? (row.expense - expense.mean) / expense.stdDev
+              : 0;
+          const netZ = net.stdDev > 0 ? (row.net - net.mean) / net.stdDev : 0;
+          const absScores = [
+            {
+              kind: "income" as const,
+              value: row.income,
+              score: Math.abs(incomeZ),
+            },
+            {
+              kind: "expense" as const,
+              value: row.expense,
+              score: Math.abs(expenseZ),
+            },
+            { kind: "net" as const, value: row.net, score: Math.abs(netZ) },
+          ];
+          const best = absScores.reduce((top, current) =>
+            current.score > top.score ? current : top,
+          );
+          if (best.score < spikeThreshold) return null;
+          return {
+            date: row.date,
+            label: row.label,
+            kind: best.kind,
+            value: best.value,
+            zScore: best.score,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => Boolean(row))
+        .sort((a, b) => b.zScore - a.zScore)
+        .slice(0, 6);
+
+      return {
+        income,
+        expense,
+        net,
+        stabilityScore,
+        spikes,
+      };
+    }, [totalMonthlyIncomeExpense, totalWindowRange]);
 
   const totalNetWorthAttribution = useMemo(() => {
     if (!totalOverview) return null;
@@ -783,6 +886,7 @@ export const useTotalAnalysis = ({
     totalNetWorthSeries,
     totalNetWorthStats,
     totalMonthlyIncomeExpense,
+    totalCashflowVolatility,
     totalNetWorthAttribution,
     totalNetWorthTrajectoryData,
     totalNetWorthTrajectoryDomain,

--- a/apps/web/src/pages/reports/hooks/use-yearly-analysis.ts
+++ b/apps/web/src/pages/reports/hooks/use-yearly-analysis.ts
@@ -2,7 +2,24 @@ import { useMemo } from "react";
 
 import type { YearlyOverviewResponse } from "@/types/api";
 
+import type {
+  CashflowVolatilityMetric,
+  CashflowVolatilitySummary,
+} from "../reports-types";
 import { monthLabel } from "../reports-utils";
+
+const volatilityStats = (values: number[]): CashflowVolatilityMetric => {
+  if (!values.length) {
+    return { mean: 0, stdDev: 0, cv: null };
+  }
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance =
+    values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
+  const stdDev = Math.sqrt(variance);
+  const meanAbs = Math.abs(mean);
+  const cv = meanAbs > 0 ? stdDev / meanAbs : null;
+  return { mean, stdDev, cv };
+};
 
 export const useYearlyAnalysis = ({
   overview,
@@ -401,6 +418,86 @@ export const useYearlyAnalysis = ({
     yearlyIncomeCategoryDeltas,
   ]);
 
+  const yearlyCashflowVolatility =
+    useMemo<CashflowVolatilitySummary | null>(() => {
+      if (!overview?.monthly?.length) return null;
+      const series = overview.monthly.map((row) => ({
+        date: row.date,
+        label: monthLabel(
+          new Date(Date.UTC(year, row.month - 1, 1)).toISOString(),
+        ),
+        income: Number(row.income),
+        expense: Number(row.expense),
+        net: Number(row.net),
+      }));
+
+      const incomeValues = series.map((row) => row.income);
+      const expenseValues = series.map((row) => row.expense);
+      const netValues = series.map((row) => row.net);
+
+      const income = volatilityStats(incomeValues);
+      const expense = volatilityStats(expenseValues);
+      const net = volatilityStats(netValues);
+
+      const cvValues = [income.cv, expense.cv, net.cv].filter(
+        (value): value is number =>
+          typeof value === "number" && !Number.isNaN(value),
+      );
+      const avgCv =
+        cvValues.length > 0
+          ? cvValues.reduce((sum, value) => sum + value, 0) / cvValues.length
+          : null;
+      const stabilityScore =
+        avgCv === null ? null : Math.max(0, 100 - Math.min(100, avgCv * 100));
+
+      const spikeThreshold = 1.5;
+      const spikes = series
+        .map((row) => {
+          const incomeZ =
+            income.stdDev > 0 ? (row.income - income.mean) / income.stdDev : 0;
+          const expenseZ =
+            expense.stdDev > 0
+              ? (row.expense - expense.mean) / expense.stdDev
+              : 0;
+          const netZ = net.stdDev > 0 ? (row.net - net.mean) / net.stdDev : 0;
+          const absScores = [
+            {
+              kind: "income" as const,
+              value: row.income,
+              score: Math.abs(incomeZ),
+            },
+            {
+              kind: "expense" as const,
+              value: row.expense,
+              score: Math.abs(expenseZ),
+            },
+            { kind: "net" as const, value: row.net, score: Math.abs(netZ) },
+          ];
+          const best = absScores.reduce((top, current) =>
+            current.score > top.score ? current : top,
+          );
+          if (best.score < spikeThreshold) return null;
+          return {
+            date: row.date,
+            label: row.label,
+            kind: best.kind,
+            value: best.value,
+            zScore: best.score,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => Boolean(row))
+        .sort((a, b) => b.zScore - a.zScore)
+        .slice(0, 6);
+
+      return {
+        income,
+        expense,
+        net,
+        stabilityScore,
+        spikes,
+      };
+    }, [overview?.monthly, year]);
+
   return {
     categoryChartData,
     heatmap,
@@ -415,5 +512,6 @@ export const useYearlyAnalysis = ({
     yearlyExpenseSourceDeltas,
     yearlyIncomeSourceDeltas,
     yearlySavingsDecomposition,
+    yearlyCashflowVolatility,
   };
 };

--- a/apps/web/src/pages/reports/reports-types.ts
+++ b/apps/web/src/pages/reports/reports-types.ts
@@ -1,5 +1,27 @@
 export type ReportMode = "yearly" | "total";
 
+export type CashflowVolatilityMetric = {
+  mean: number;
+  stdDev: number;
+  cv: number | null;
+};
+
+export type CashflowSpikeMonth = {
+  date: string;
+  label: string;
+  kind: "income" | "expense" | "net";
+  value: number;
+  zScore: number;
+};
+
+export type CashflowVolatilitySummary = {
+  income: CashflowVolatilityMetric;
+  expense: CashflowVolatilityMetric;
+  net: CashflowVolatilityMetric;
+  stabilityScore: number | null;
+  spikes: CashflowSpikeMonth[];
+};
+
 export type DetailDialogState =
   | {
       kind: "investments";

--- a/apps/web/src/pages/reports/total/total-reports-page.tsx
+++ b/apps/web/src/pages/reports/total/total-reports-page.tsx
@@ -11,6 +11,7 @@ import type {
   YearlyReportEntry,
   YearlyOverviewResponse,
 } from "@/types/api";
+import { CashflowVolatilityCard } from "../components/cashflow-volatility-card";
 import { ReportsOverviewCard } from "../components/reports-overview-card";
 import { TotalAccountsOverviewCard } from "../components/total-accounts-overview-card";
 import { TotalCategoryByYearCard } from "../components/total-category-by-year-card";
@@ -117,6 +118,7 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
     totalKpis,
     totalNetWorthSeries,
     totalNetWorthStats,
+    totalCashflowVolatility,
     totalNetWorthAttribution,
     totalNetWorthTrajectoryData,
     totalNetWorthTrajectoryDomain,
@@ -329,6 +331,13 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
         incomeCategories={totalIncomeCategoriesLifetime}
         expenseCategories={totalExpenseCategoriesLifetime}
         loading={totalOverviewLoading}
+      />
+
+      <CashflowVolatilityCard
+        title="Cashflow stability"
+        description="Monthly volatility for income, expense, and net across the selected window."
+        loading={totalOverviewLoading}
+        volatility={totalCashflowVolatility}
       />
 
       <div className="grid gap-3 lg:grid-cols-2">

--- a/apps/web/src/pages/reports/yearly/yearly-reports-page.tsx
+++ b/apps/web/src/pages/reports/yearly/yearly-reports-page.tsx
@@ -8,6 +8,7 @@ import type {
   YearlyCategoryDetailResponse,
   YearlyOverviewResponse,
 } from "@/types/api";
+import { CashflowVolatilityCard } from "../components/cashflow-volatility-card";
 import { ReportsOverviewCard } from "../components/reports-overview-card";
 import { YearlyAccountFlowsCard } from "../components/yearly-account-flows-card";
 import { YearlyCategoryBreakdownCard } from "../components/yearly-category-breakdown-card";
@@ -78,6 +79,7 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
     yearlyExpenseSourceDeltas,
     yearlyIncomeSourceDeltas,
     yearlySavingsDecomposition,
+    yearlyCashflowVolatility,
   } = useYearlyAnalysis({
     overview,
     prevOverview,
@@ -225,7 +227,7 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
         loading={overviewLoading}
       />
 
-      <div className="grid gap-3 lg:grid-cols-3">
+      <div className="grid gap-3 lg:grid-cols-2">
         <YearlyDebtCard
           year={year}
           loading={overviewLoading}
@@ -233,10 +235,18 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
           debtOverview={overview?.debt_overview ?? null}
           onOpenDetailDialog={openDetailDialog}
         />
+        <YearlySummaryCard year={year} overview={overview} />
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <CashflowVolatilityCard
+          title="Cashflow stability"
+          description={`Monthly volatility for income, expense, and net in ${year}.`}
+          loading={overviewLoading}
+          volatility={yearlyCashflowVolatility}
+        />
 
         <YearlySavingsRateCard savings={overview?.savings} />
-
-        <YearlySummaryCard year={year} overview={overview} />
       </div>
 
       <YearlyDriversGrid


### PR DESCRIPTION
### Motivation

- Surface monthly cashflow volatility (std dev + coefficient of variation) to help identify instability in income, expense, and net series.
- Detect and highlight spike months (outliers) so users can quickly spot anomalous months.
- Provide a compact “Stability score” to summarize volatility across income/expense/net.
- Show this information in both yearly and total report contexts and handle missing monthly series gracefully.

### Description

- Added new types `CashflowVolatilityMetric`, `CashflowSpikeMonth`, and `CashflowVolatilitySummary` in `apps/web/src/pages/reports/reports-types.ts`.
- Implemented volatility computation and spike detection (1.5σ threshold) in `use-yearly-analysis.ts` and `use-total-analysis.ts` via a `volatilityStats` helper that returns mean, std dev, and CV and computes a stability score from average CV.
- New UI component `apps/web/src/pages/reports/components/cashflow-volatility-card.tsx` renders the Stability score, metrics (std dev/CV) and top spike months, and is wired into `yearly-reports-page.tsx` and `total-reports-page.tsx`.
- Minor import/order and formatting adjustments to keep linting clean.

### Testing

- Ran `npm run format -w apps/web` (succeeded).
- Ran `npm run lint -w apps/web` (succeeded; TypeScript checks pass via the lint script).
- Attempted an automated Playwright screenshot of the reports page which failed due to a Chromium launch crash in the environment (no UI screenshot available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dc7bb8618832d981c2c1fc6b6af18)