### PR TITLE
Add category concentration insights to reports

### DIFF
--- a/apps/web/src/pages/reports/components/category-concentration-card.tsx
+++ b/apps/web/src/pages/reports/components/category-concentration-card.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+
+import { EmptyState } from "@/components/composed/empty-state";
+import { LoadingCard } from "@/components/composed/loading-card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import type { CategoryConcentration } from "../reports-utils";
+import { percent } from "../reports-utils";
+
+export const CategoryConcentrationCard: React.FC<{
+  flow: "income" | "expense";
+  loading: boolean;
+  hasOverview: boolean;
+  concentration: CategoryConcentration | null;
+}> = ({ flow, loading, hasOverview, concentration }) => {
+  const title =
+    flow === "income"
+      ? "Income category concentration"
+      : "Expense category concentration";
+  const accent = flow === "income" ? "#10b981" : "#ef4444";
+
+  return (
+    <Card className="border-slate-200 shadow-[0_10px_40px_-20px_rgba(15,23,42,0.4)]">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-slate-900">
+          {title}
+        </CardTitle>
+        <p className="text-xs text-slate-500">
+          How much of the total sits in the top categories.
+        </p>
+      </CardHeader>
+      <CardContent>
+        {loading && !hasOverview ? (
+          <LoadingCard className="h-56" lines={6} />
+        ) : !concentration ? (
+          <EmptyState className="h-56" title="No category data yet." />
+        ) : (
+          <div className="grid gap-4 md:grid-cols-[1.1fr_1fr]">
+            <div className="space-y-3">
+              <div className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
+                <p className="text-xs text-slate-400 uppercase">Top 3 share</p>
+                <p className="mt-2 text-2xl font-semibold text-slate-900">
+                  {percent(concentration.topSharePct)}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Combined share of the three biggest categories.
+                </p>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
+                <p className="text-xs text-slate-400 uppercase">
+                  Diversity score
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-slate-900">
+                  {percent(concentration.diversityScore)}
+                </p>
+                <p className="text-xs text-slate-500">
+                  Higher means the mix is more balanced.
+                </p>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs font-semibold tracking-wide text-slate-400 uppercase">
+                Top categories
+              </p>
+              {concentration.topCategories.map((row) => (
+                <div
+                  key={row.name}
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm"
+                >
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium text-slate-700">
+                      {row.name}
+                    </span>
+                    <span className="text-slate-500">
+                      {percent(row.sharePct)}
+                    </span>
+                  </div>
+                  <div className="mt-2 h-1.5 w-full rounded-full bg-slate-100">
+                    <div
+                      className="h-1.5 rounded-full"
+                      style={{
+                        width: `${Math.min(100, row.sharePct)}%`,
+                        backgroundColor: accent,
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/pages/reports/hooks/use-total-analysis.ts
+++ b/apps/web/src/pages/reports/hooks/use-total-analysis.ts
@@ -2,7 +2,11 @@ import { useMemo } from "react";
 
 import type { TotalOverviewResponse } from "@/types/api";
 
-import { formatDate, monthLabel } from "../reports-utils";
+import {
+  computeCategoryConcentration,
+  formatDate,
+  monthLabel,
+} from "../reports-utils";
 
 type TotalWindowPreset = "all" | "10" | "5" | "3";
 type TotalWindowRange = { start: string; end: string } | null;
@@ -560,6 +564,16 @@ export const useTotalAnalysis = ({
       .sort((a, b) => b.total - a.total);
   }, [totalOverview]);
 
+  const totalExpenseCategoryConcentration = useMemo(
+    () => computeCategoryConcentration(totalExpenseCategoriesLifetime),
+    [totalExpenseCategoriesLifetime],
+  );
+
+  const totalIncomeCategoryConcentration = useMemo(
+    () => computeCategoryConcentration(totalIncomeCategoriesLifetime),
+    [totalIncomeCategoriesLifetime],
+  );
+
   const totalExpenseCategoryChanges = useMemo(() => {
     if (!totalOverview) return [];
     return totalOverview.expense_category_changes_yoy
@@ -796,6 +810,8 @@ export const useTotalAnalysis = ({
     totalInvestmentsYearlyTable,
     totalExpenseCategoriesLifetime,
     totalIncomeCategoriesLifetime,
+    totalExpenseCategoryConcentration,
+    totalIncomeCategoryConcentration,
     totalExpenseCategoryChanges,
     totalIncomeCategoryChanges,
     totalIncomeSourcesLifetime,

--- a/apps/web/src/pages/reports/hooks/use-yearly-analysis.ts
+++ b/apps/web/src/pages/reports/hooks/use-yearly-analysis.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import type { YearlyOverviewResponse } from "@/types/api";
 
-import { monthLabel } from "../reports-utils";
+import { computeCategoryConcentration, monthLabel } from "../reports-utils";
 
 export const useYearlyAnalysis = ({
   overview,
@@ -52,6 +52,16 @@ export const useYearlyAnalysis = ({
     );
     return { rows: incomeCategoryChartData, max };
   }, [incomeCategoryChartData]);
+
+  const expenseCategoryConcentration = useMemo(
+    () => computeCategoryConcentration(categoryChartData),
+    [categoryChartData],
+  );
+
+  const incomeCategoryConcentration = useMemo(
+    () => computeCategoryConcentration(incomeCategoryChartData),
+    [incomeCategoryChartData],
+  );
 
   const incomeSourceRows = useMemo(() => {
     if (!overview?.income_sources) return [];
@@ -410,6 +420,8 @@ export const useYearlyAnalysis = ({
     expenseSourceRows,
     prevIncomeSourceRows,
     prevExpenseSourceRows,
+    expenseCategoryConcentration,
+    incomeCategoryConcentration,
     yearlyExpenseCategoryDeltas,
     yearlyIncomeCategoryDeltas,
     yearlyExpenseSourceDeltas,

--- a/apps/web/src/pages/reports/reports-utils.ts
+++ b/apps/web/src/pages/reports/reports-utils.ts
@@ -70,3 +70,53 @@ export const heatColor = (rgb: string, value: number, max: number) => {
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
+
+export type CategoryConcentration = {
+  total: number;
+  topSharePct: number;
+  diversityScore: number;
+  topCategories: Array<{
+    name: string;
+    total: number;
+    sharePct: number;
+  }>;
+};
+
+export const computeCategoryConcentration = (
+  rows: Array<{ name: string; total: number }>,
+  topN = 3,
+): CategoryConcentration | null => {
+  if (!rows.length) return null;
+  const normalized = rows.map((row) => ({
+    name: row.name,
+    total: Math.abs(row.total),
+  }));
+  const total = normalized.reduce((sum, row) => sum + row.total, 0);
+  if (total <= 0) return null;
+
+  const topCategories = normalized
+    .filter((row) => row.name !== "Other")
+    .sort((a, b) => b.total - a.total)
+    .slice(0, topN)
+    .map((row) => ({
+      name: row.name,
+      total: row.total,
+      sharePct: (row.total / total) * 100,
+    }));
+
+  const topSharePct = topCategories.reduce((sum, row) => sum + row.sharePct, 0);
+
+  const concentration = normalized.reduce((sum, row) => {
+    if (row.total <= 0) return sum;
+    const share = row.total / total;
+    return sum + share * share;
+  }, 0);
+  const diversityScore = Math.max(0, (1 - concentration) * 100);
+
+  return {
+    total,
+    topSharePct,
+    diversityScore,
+    topCategories,
+  };
+};

--- a/apps/web/src/pages/reports/total/total-reports-page.tsx
+++ b/apps/web/src/pages/reports/total/total-reports-page.tsx
@@ -11,6 +11,7 @@ import type {
   YearlyReportEntry,
   YearlyOverviewResponse,
 } from "@/types/api";
+import { CategoryConcentrationCard } from "../components/category-concentration-card";
 import { ReportsOverviewCard } from "../components/reports-overview-card";
 import { TotalAccountsOverviewCard } from "../components/total-accounts-overview-card";
 import { TotalCategoryByYearCard } from "../components/total-category-by-year-card";
@@ -127,6 +128,8 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
     totalInvestmentsYearlyTable,
     totalExpenseCategoriesLifetime,
     totalIncomeCategoriesLifetime,
+    totalExpenseCategoryConcentration,
+    totalIncomeCategoryConcentration,
     totalExpenseCategoryChanges,
     totalIncomeCategoryChanges,
     totalIncomeSourcesLifetime,
@@ -364,6 +367,22 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
           yearlyTotals={totalYearly}
           onOpenDrilldownDialog={openTotalDrilldownDialog}
           onOpenHeatmapDialog={openTotalHeatmapDialog}
+        />
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <CategoryConcentrationCard
+          flow="expense"
+          loading={totalOverviewLoading}
+          hasOverview={totalOverviewLoaded}
+          concentration={totalExpenseCategoryConcentration}
+        />
+
+        <CategoryConcentrationCard
+          flow="income"
+          loading={totalOverviewLoading}
+          hasOverview={totalOverviewLoaded}
+          concentration={totalIncomeCategoryConcentration}
         />
       </div>
 

--- a/apps/web/src/pages/reports/yearly/yearly-reports-page.tsx
+++ b/apps/web/src/pages/reports/yearly/yearly-reports-page.tsx
@@ -8,6 +8,7 @@ import type {
   YearlyCategoryDetailResponse,
   YearlyOverviewResponse,
 } from "@/types/api";
+import { CategoryConcentrationCard } from "../components/category-concentration-card";
 import { ReportsOverviewCard } from "../components/reports-overview-card";
 import { YearlyAccountFlowsCard } from "../components/yearly-account-flows-card";
 import { YearlyCategoryBreakdownCard } from "../components/yearly-category-breakdown-card";
@@ -73,6 +74,8 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
     expenseSourceRows,
     prevIncomeSourceRows,
     prevExpenseSourceRows,
+    expenseCategoryConcentration,
+    incomeCategoryConcentration,
     yearlyExpenseCategoryDeltas,
     yearlyIncomeCategoryDeltas,
     yearlyExpenseSourceDeltas,
@@ -255,7 +258,7 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
         }}
       />
 
-      <div className="grid gap-3 lg:grid-cols-2">
+      <div className="grid gap-3 lg:grid-cols-3">
         <YearlyCategoryBreakdownCard
           flow="expense"
           loading={overviewLoading}
@@ -264,6 +267,13 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
             setSelectedCategoryFlow("expense");
             setSelectedCategoryId(categoryId);
           }}
+        />
+
+        <CategoryConcentrationCard
+          flow="expense"
+          loading={overviewLoading}
+          hasOverview={Boolean(overview)}
+          concentration={expenseCategoryConcentration}
         />
 
         <YearlyCategoryHeatmapCard
@@ -276,7 +286,7 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
         />
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-2">
+      <div className="grid gap-3 lg:grid-cols-3">
         <YearlyCategoryBreakdownCard
           flow="income"
           loading={overviewLoading}
@@ -285,6 +295,13 @@ export const YearlyReportsPage: React.FC<YearlyReportsPageProps> = ({
             setSelectedCategoryFlow("income");
             setSelectedCategoryId(categoryId);
           }}
+        />
+
+        <CategoryConcentrationCard
+          flow="income"
+          loading={overviewLoading}
+          hasOverview={Boolean(overview)}
+          concentration={incomeCategoryConcentration}
         />
 
         <YearlyCategoryHeatmapCard


### PR DESCRIPTION
### Motivation
- Surface how concentrated income and expense categories are by computing top-N share and a simple diversity score to help surface dependency on a few categories. 
- Provide a compact UI card that shows the top-3 share and a diversity metric for quick inspection next to existing breakdowns and heatmaps. 
- Reuse existing report data shapes and utilities to keep calculations consistent with other report visuals. 

### Description
- Added `computeCategoryConcentration` and `CategoryConcentration` type to `pages/reports/reports-utils.ts` to compute top-N share and a diversity score. 
- Wired concentration computation into analysis hooks by updating `use-yearly-analysis.ts` and `use-total-analysis.ts` to produce expense and income concentration results. 
- Added a new presentational component `category-concentration-card.tsx` under `pages/reports/components/` to render top-3 share, diversity score, and a small top-categories list. 
- Integrated the new card into `yearly-reports-page.tsx` and `total-reports-page.tsx`, adjusting grid layouts so the concentration card appears alongside category breakdown and heatmap sections. 

### Testing
- Ran `npm run format -w apps/web` to apply formatting and it completed successfully. 
- Ran `npm run lint -w apps/web` (which includes `tsc --noEmit`) and the lint/type checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dc7c6a038832d98ed85c4313da3df)