### PR TITLE
Add cash runway card to Total Reports and compute average monthly expense

### DIFF
--- a/apps/web/src/pages/reports/components/cash-runway-card.tsx
+++ b/apps/web/src/pages/reports/components/cash-runway-card.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo } from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { currency, formatDate } from "../reports-utils";
+
+type TotalWindowRange = { start: string; end: string } | null;
+
+type TotalAverageExpense = {
+  average: number;
+  months: number;
+  total: number;
+};
+
+type TotalMoneySnapshot = {
+  asOf: string | null;
+  cash: number;
+};
+
+export const CashRunwayCard: React.FC<{
+  loading: boolean;
+  windowRange: TotalWindowRange;
+  averageExpense: TotalAverageExpense | null;
+  cashSnapshot: TotalMoneySnapshot | null;
+  runwayMonths: number | null;
+}> = ({ loading, windowRange, averageExpense, cashSnapshot, runwayMonths }) => {
+  const windowLabel = useMemo(() => {
+    if (!windowRange) return "—";
+    const start = formatDate(windowRange.start, {
+      month: "short",
+      year: "numeric",
+    });
+    const end = formatDate(windowRange.end, {
+      month: "short",
+      year: "numeric",
+    });
+    return `${start} → ${end}`;
+  }, [windowRange]);
+
+  const hasData = Boolean(
+    averageExpense && cashSnapshot && Number.isFinite(runwayMonths ?? NaN),
+  );
+
+  return (
+    <Card className="border-slate-200 shadow-[0_10px_40px_-20px_rgba(15,23,42,0.4)]">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+        <div>
+          <CardTitle className="text-base font-semibold text-slate-900">
+            Cash runway
+          </CardTitle>
+          <p className="text-xs text-slate-500">
+            Liquid cash divided by average monthly expenses.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : !hasData ? (
+          <div className="flex h-32 items-center justify-center text-sm text-slate-600">
+            Not enough data to estimate runway yet.
+          </div>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-md border border-slate-100 bg-slate-50 p-3">
+              <p className="text-xs tracking-wide text-slate-500 uppercase">
+                Liquid cash
+              </p>
+              <p className="text-lg font-semibold text-slate-900">
+                {currency(cashSnapshot?.cash ?? 0)}
+              </p>
+              <p className="text-[11px] text-slate-500">
+                As of{" "}
+                {formatDate(cashSnapshot?.asOf ?? new Date().toISOString(), {
+                  month: "short",
+                  year: "numeric",
+                  day: "numeric",
+                })}
+              </p>
+            </div>
+            <div className="rounded-md border border-slate-100 bg-slate-50 p-3">
+              <p className="text-xs tracking-wide text-slate-500 uppercase">
+                Avg monthly expense
+              </p>
+              <p className="text-lg font-semibold text-slate-900">
+                {currency(averageExpense?.average ?? 0)}
+              </p>
+              <p className="text-[11px] text-slate-500">
+                Window: {windowLabel}
+              </p>
+            </div>
+            <div className="rounded-md border border-slate-100 bg-emerald-50 p-3">
+              <p className="text-xs tracking-wide text-emerald-700 uppercase">
+                Runway
+              </p>
+              <p className="text-2xl font-semibold text-emerald-700">
+                {(runwayMonths ?? 0).toFixed(1)} months
+              </p>
+              <p className="text-[11px] text-emerald-700/70">
+                At current average spend rate
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/web/src/pages/reports/components/total-money-position-card.tsx
+++ b/apps/web/src/pages/reports/components/total-money-position-card.tsx
@@ -30,6 +30,7 @@ type TotalMoneySnapshot = {
   asOf: string | null;
   total: number;
   debt: number;
+  cash: number;
 };
 
 export const TotalMoneyPositionCard: React.FC<{

--- a/apps/web/src/pages/reports/total/total-reports-page.tsx
+++ b/apps/web/src/pages/reports/total/total-reports-page.tsx
@@ -11,6 +11,7 @@ import type {
   YearlyReportEntry,
   YearlyOverviewResponse,
 } from "@/types/api";
+import { CashRunwayCard } from "../components/cash-runway-card";
 import { ReportsOverviewCard } from "../components/reports-overview-card";
 import { TotalAccountsOverviewCard } from "../components/total-accounts-overview-card";
 import { TotalCategoryByYearCard } from "../components/total-category-by-year-card";
@@ -137,6 +138,8 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
     totalDebtSeries,
     totalMoneySeries,
     totalMoneySnapshot,
+    totalAverageMonthlyExpense,
+    totalCashRunwayMonths,
     totalDebtAccounts,
     totalSeasonalityHeatmaps,
     totalExpenseCategoryYearHeatmap,
@@ -295,6 +298,14 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
           loading={totalOverviewLoading}
           series={totalMoneySeries}
           snapshot={totalMoneySnapshot}
+        />
+
+        <CashRunwayCard
+          loading={totalOverviewLoading}
+          windowRange={totalWindowRange}
+          averageExpense={totalAverageMonthlyExpense}
+          cashSnapshot={totalMoneySnapshot}
+          runwayMonths={totalCashRunwayMonths}
         />
 
         <TotalNetWorthGrowthCard


### PR DESCRIPTION
### Motivation

- Provide a quick liquidity runway estimate by dividing liquid cash by recent average monthly expenses for the selected report window.
- Surface runway information alongside existing total money and net worth views without adding new API calls by reusing `totalMoneySnapshot` and existing monthly expense series.

### Description

- Compute average monthly expense for the selected window in `useTotalAnalysis` and expose it as `totalAverageMonthlyExpense` and a derived `totalCashRunwayMonths` value.  
- Extend `totalMoneySnapshot` to include `cash` (liquid cash) so the runway can be computed from existing KPIs.  
- Add a new UI component `CashRunwayCard` at `apps/web/src/pages/reports/components/cash-runway-card.tsx` and wire it into the Total reports page (`total-reports-page.tsx`).  
- Update the `TotalMoneyPositionCard` snapshot type to include `cash` for consistency with the snapshot shape returned from the hook.

### Testing

- Ran formatting with `npm run format -w apps/web` and it completed successfully.  
- Ran lint/type-check with `npm run lint -w apps/web` and it passed after import order fix.  
- Started the dev server (`npm run dev -w apps/web`) and verified the reports page renders (local smoke check).  
- No backend/API changes were required, and no new tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dc7d2e454832db9196dac67761498)