### PR TITLE
Fix transfer selection text contrast in imports audit

### DIFF
--- a/apps/web/src/pages/imports/imports.tsx
+++ b/apps/web/src/pages/imports/imports.tsx
@@ -1973,8 +1973,8 @@ export const Imports: React.FC = () => {
                                         categories={rowCategories}
                                         disabled={Boolean(
                                           taxEventType ||
-                                            transferAccountId ||
-                                            isDeleted,
+                                          transferAccountId ||
+                                          isDeleted,
                                         )}
                                         missing={isMissingCategory}
                                         suggesting={
@@ -2748,14 +2748,33 @@ export const Imports: React.FC = () => {
                             className="h-auto justify-start gap-3 text-left"
                             onClick={() => setTransferDraftValue(acc.id)}
                           >
-                            <div className="flex h-9 w-9 items-center justify-center rounded bg-slate-100 text-xs font-semibold text-slate-700">
+                            <div
+                              className={cn(
+                                "flex h-9 w-9 items-center justify-center rounded text-xs font-semibold",
+                                selected
+                                  ? "bg-white/10 text-white"
+                                  : "bg-slate-100 text-slate-700",
+                              )}
+                            >
                               {acc.name.slice(0, 2).toUpperCase()}
                             </div>
                             <div className="flex flex-col">
-                              <span className="text-sm font-semibold text-slate-900">
+                              <span
+                                className={cn(
+                                  "text-sm font-semibold",
+                                  selected ? "text-white" : "text-slate-900",
+                                )}
+                              >
                                 {acc.name}
                               </span>
-                              <span className="text-xs text-slate-500">
+                              <span
+                                className={cn(
+                                  "text-xs",
+                                  selected
+                                    ? "text-slate-200"
+                                    : "text-slate-500",
+                                )}
+                              >
                                 {bankLabel(acc.bank_import_type)}
                               </span>
                             </div>


### PR DESCRIPTION
### Motivation
- The transfer create/list in the imports audit used a dark button background when selected but left text colors unchanged, making labels unreadable.
- Improve accessibility and visual contrast for selected transfer targets so users can clearly read account names and bank labels.

### Description
- Updated `apps/web/src/pages/imports/imports.tsx` to apply conditional styling using `cn` for account avatar, name, and bank label when a transfer target is selected.
- Added selected-state classes (`bg-white/10`, `text-white`, `text-slate-200`) and preserved the original unselected styles.
- Kept existing button `variant` behavior (`default` vs `outline`) and only adjusted internal label/avatar colors to maintain consistency.

### Testing
- Ran `npm run format -w apps/web` and it completed successfully.
- Ran `npm run lint -w apps/web` (ESLint + TypeScript) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dca874f64832da2b3c023f835885e)