### PR TITLE
Redesign goals page for net worth milestones

### DIFF
--- a/apps/api/handlers/goals.py
+++ b/apps/api/handlers/goals.py
@@ -78,10 +78,12 @@ def delete_goal(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
 
 
 def _to_schema(service: GoalService, goal: Goal) -> GoalRead:
-    current, pct = service.progress(goal)
+    current, pct, achieved_at, achieved_delta_days = service.progress(goal)
     payload = goal.model_dump(mode="python")
     payload["current_amount"] = current
     payload["progress_pct"] = pct
+    payload["achieved_at"] = achieved_at
+    payload["achieved_delta_days"] = achieved_delta_days
     return GoalRead.model_validate(payload)
 
 

--- a/apps/api/schemas/goal.py
+++ b/apps/api/schemas/goal.py
@@ -51,6 +51,8 @@ class GoalRead(BaseModel):
     updated_at: datetime
     current_amount: Decimal
     progress_pct: float
+    achieved_at: Optional[date] = None
+    achieved_delta_days: Optional[int] = None
 
 
 class GoalListResponse(BaseModel):

--- a/apps/web/src/pages/goals/goals.tsx
+++ b/apps/web/src/pages/goals/goals.tsx
@@ -1,30 +1,53 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CheckCircle, Goal as GoalIcon, Plus } from "lucide-react";
+import { ShaderGradient, ShaderGradientCanvas } from "@shadergradient/react";
+import { motion, useReducedMotion } from "framer-motion";
+import {
+  Award,
+  CalendarClock,
+  CheckCircle2,
+  Goal as GoalIcon,
+  Plus,
+  Sparkles,
+  Target,
+  Trophy,
+} from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { useAppSelector } from "@/app/hooks";
-import { MotionPage } from "@/components/motion-presets";
+import {
+  fadeInUp,
+  MotionPage,
+  StaggerWrap,
+  subtleHover,
+} from "@/components/motion-presets";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
+import { Textarea } from "@/components/ui/textarea";
 import { selectToken } from "@/features/auth/authSlice";
-import { useAccountsApi, useCategoriesApi } from "@/hooks/use-api";
 import { apiFetch } from "@/lib/apiClient";
 import { currency, formatDate as formatDateLabel } from "@/lib/format";
-import { type GoalRead, type GoalListResponse } from "@/types/api";
+import { cn } from "@/lib/utils";
+import { type GoalListResponse, type GoalRead } from "@/types/api";
 import { goalListSchema } from "@/types/schemas";
 
 const goalFormSchema = z.object({
   name: z.string().min(1, "Name required").trim(),
   target_amount: z.string().min(1, "Target amount required").trim(),
   target_date: z.string().optional(),
-  category_id: z.string().optional(),
-  account_id: z.string().optional(),
-  subscription_id: z.string().optional(),
   note: z.string().optional(),
 });
 
@@ -32,43 +55,41 @@ type GoalFormValues = z.infer<typeof goalFormSchema>;
 
 const formatCurrency = (value: string | number) =>
   currency(Number(value || 0), {
-    locale: "en-US",
-    currency: "USD",
     maximumFractionDigits: 0,
   });
 
 const formatDate = (value?: string | null) => {
-  if (!value) return "No target date";
-  const date = new Date(value);
-  return formatDateLabel(date, {
+  if (!value) return "Open-ended";
+  return formatDateLabel(value, {
     month: "short",
     day: "numeric",
     year: "numeric",
   });
 };
 
+const formatDelta = (deltaDays: number) => {
+  if (deltaDays === 0) return "On time";
+  const abs = Math.abs(deltaDays);
+  return deltaDays < 0 ? `${abs} days early` : `${abs} days late`;
+};
+
 export const Goals: React.FC = () => {
   const token = useAppSelector(selectToken);
-  const { items: accounts, fetchAccounts } = useAccountsApi();
-  const { items: categories, fetchCategories } = useCategoriesApi();
+  const prefersReducedMotion = useReducedMotion();
   const [goals, setGoals] = useState<GoalRead[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const goalForm = useForm<GoalFormValues>({
     resolver: zodResolver(goalFormSchema),
     defaultValues: {
       name: "",
       target_amount: "",
       target_date: "",
-      category_id: "",
-      account_id: "",
-      subscription_id: "",
       note: "",
     },
   });
 
   useEffect(() => {
-    fetchAccounts({});
-    fetchCategories();
     void loadGoals();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -101,9 +122,6 @@ export const Goals: React.FC = () => {
         body: {
           ...values,
           target_date: values.target_date || null,
-          category_id: values.category_id || null,
-          account_id: values.account_id || null,
-          subscription_id: values.subscription_id || null,
           note: values.note || null,
         },
       });
@@ -112,11 +130,9 @@ export const Goals: React.FC = () => {
         name: "",
         target_amount: "",
         target_date: "",
-        category_id: "",
-        account_id: "",
-        subscription_id: "",
         note: "",
       });
+      setIsDialogOpen(false);
       void loadGoals();
     } catch (error) {
       toast.error("Unable to add goal", {
@@ -125,201 +141,518 @@ export const Goals: React.FC = () => {
     }
   });
 
-  const totals = useMemo(() => {
+  const stats = useMemo(() => {
     const totalTarget = goals.reduce(
       (sum, goal) => sum + Number(goal.target_amount || 0),
       0,
     );
-    const totalCurrent = goals.reduce(
-      (sum, goal) => sum + Number(goal.current_amount || 0),
-      0,
-    );
-    const avgProgress = Math.round(
-      (totalCurrent / Math.max(1, totalTarget)) * 100,
-    );
-    return { totalTarget, totalCurrent, avgProgress };
+    const currentNetWorth = goals.length
+      ? Math.max(...goals.map((goal) => Number(goal.current_amount || 0)))
+      : 0;
+    const achievedGoals = goals.filter((goal) => goal.progress_pct >= 100);
+    const activeGoals = goals.filter((goal) => goal.progress_pct < 100);
+    const avgProgress = totalTarget
+      ? Math.min(100, Math.round((currentNetWorth / totalTarget) * 100))
+      : 0;
+    const nextGoal = activeGoals
+      .filter((goal) => goal.target_date)
+      .sort(
+        (a, b) =>
+          new Date(a.target_date ?? "").getTime() -
+          new Date(b.target_date ?? "").getTime(),
+      )[0];
+    const achievedWithDelta = achievedGoals
+      .map((goal) => goal.achieved_delta_days)
+      .filter((value): value is number => typeof value === "number");
+    const avgDelta = achievedWithDelta.length
+      ? Math.round(
+          achievedWithDelta.reduce((sum, value) => sum + value, 0) /
+            achievedWithDelta.length,
+        )
+      : null;
+
+    return {
+      totalTarget,
+      currentNetWorth,
+      achievedGoals,
+      activeGoals,
+      avgProgress,
+      nextGoal,
+      avgDelta,
+    };
   }, [goals]);
 
   return (
-    <MotionPage className="space-y-4">
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div>
-          <p className="text-xs tracking-wide text-slate-500 uppercase">
-            Goals
-          </p>
-          <h1 className="text-2xl font-semibold text-slate-900">
-            Track targets with clarity
-          </h1>
-          <p className="text-sm text-slate-500">
-            Link targets to categories or accounts and monitor progress
-            automatically.
-          </p>
+    <MotionPage className="space-y-10 pb-12">
+      <section className="relative overflow-hidden rounded-3xl border border-slate-200 bg-slate-950 text-white shadow-[0_35px_80px_-55px_rgba(15,23,42,0.9)]">
+        <div className="pointer-events-none absolute inset-0">
+          <ShaderGradientCanvas
+            style={{ position: "absolute", inset: 0 }}
+            pixelDensity={1.4}
+          >
+            <ShaderGradient
+              animate={prefersReducedMotion ? "off" : "on"}
+              axesHelper="off"
+              brightness={1}
+              cAzimuthAngle={180}
+              cDistance={2.6}
+              cPolarAngle={90}
+              cameraZoom={1}
+              color1="#d9a2ff"
+              color2="#6cc7ff"
+              color3="#ffe3c2"
+              destination="onCanvas"
+              envPreset="lobby"
+              frameRate={10}
+              grain="on"
+              lightType="3d"
+              pixelDensity={1.4}
+              positionX={-0.5}
+              positionY={0}
+              positionZ={0}
+              range="disabled"
+              reflection={0.3}
+              rotationX={0}
+              rotationY={20}
+              rotationZ={35}
+              shader="defaults"
+              type="plane"
+              uAmplitude={1}
+              uDensity={2}
+              uFrequency={5.6}
+              uSpeed={0.15}
+              uStrength={3.4}
+              uTime={0}
+              wireframe={false}
+            />
+          </ShaderGradientCanvas>
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-950/35 via-slate-950/70 to-slate-950/90" />
         </div>
-        <form className="flex flex-wrap gap-2" onSubmit={submitGoal}>
-          <div className="flex flex-col gap-1">
-            <Input
-              placeholder="Goal name"
-              className="w-48"
-              {...goalForm.register("name")}
-            />
-            {goalForm.formState.errors.name ? (
-              <span className="text-xs text-rose-600">
-                {goalForm.formState.errors.name.message}
-              </span>
-            ) : null}
-          </div>
-          <div className="flex flex-col gap-1">
-            <Input
-              type="number"
-              placeholder="Target amount"
-              className="w-32"
-              {...goalForm.register("target_amount")}
-            />
-            {goalForm.formState.errors.target_amount ? (
-              <span className="text-xs text-rose-600">
-                {goalForm.formState.errors.target_amount.message}
-              </span>
-            ) : null}
-          </div>
-          <Input
-            type="date"
-            className="w-40"
-            {...goalForm.register("target_date")}
-          />
-          <select
-            className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800"
-            {...goalForm.register("account_id")}
-          >
-            <option value="">Account (optional)</option>
-            {accounts.map((acc, idx) => (
-              <option key={acc.id} value={acc.id}>
-                {`Account ${idx + 1}`} · {acc.account_type}
-              </option>
-            ))}
-          </select>
-          <select
-            className="rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800"
-            {...goalForm.register("category_id")}
-          >
-            <option value="">Category (optional)</option>
-            {categories.map((cat) => (
-              <option key={cat.id} value={cat.id}>
-                {cat.name}
-              </option>
-            ))}
-          </select>
-          <Button className="gap-2" type="submit">
-            <Plus className="h-4 w-4" /> Add goal
-          </Button>
-        </form>
-      </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
-        <Card className="border-slate-200 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.35)]">
-          <CardHeader>
-            <CardTitle className="text-sm text-slate-600">
-              Saved so far
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-2xl font-semibold text-slate-900">
-            {formatCurrency(totals.totalCurrent)}
-          </CardContent>
-        </Card>
-        <Card className="border-slate-200 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.35)]">
-          <CardHeader>
-            <CardTitle className="text-sm text-slate-600">
-              Target total
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-2xl font-semibold text-slate-900">
-            {formatCurrency(totals.totalTarget)}
-          </CardContent>
-        </Card>
-        <Card className="border-slate-200 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.35)]">
-          <CardHeader>
-            <CardTitle className="text-sm text-slate-600">
-              Average progress
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center gap-2 text-2xl font-semibold text-slate-900">
-              {totals.avgProgress}%
-              <CheckCircle className="h-5 w-5 text-emerald-600" />
+        <div className="relative z-10 grid gap-8 px-6 py-10 md:px-10 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="space-y-6">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold tracking-[0.2em] text-white/80 uppercase">
+              <Sparkles className="h-3.5 w-3.5" /> Total assets goals
             </div>
-            <Progress value={totals.avgProgress} className="mt-2" />
+            <div className="space-y-4">
+              <h1 className="text-3xl font-semibold tracking-tight text-white md:text-4xl">
+                Make net worth milestones feel inevitable.
+              </h1>
+              <p className="max-w-xl text-sm text-white/70 md:text-base">
+                Focus on the only thing that matters: total assets. Set bold
+                milestones, track momentum, and celebrate every breakthrough.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button className="gap-2 bg-white text-slate-900 hover:bg-white/90">
+                    <Plus className="h-4 w-4" /> Create goal
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="border-slate-200 bg-white">
+                  <DialogHeader>
+                    <DialogTitle>Set a total assets goal</DialogTitle>
+                    <DialogDescription>
+                      Your goal will track total assets and show progress over
+                      time.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <form className="space-y-4" onSubmit={submitGoal}>
+                    <div className="space-y-1">
+                      <label className="text-xs font-semibold text-slate-600">
+                        Goal name
+                      </label>
+                      <Input
+                        placeholder="Reach 1,000,000 SEK"
+                        {...goalForm.register("name")}
+                      />
+                      {goalForm.formState.errors.name ? (
+                        <span className="text-xs text-rose-600">
+                          {goalForm.formState.errors.name.message}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <label className="text-xs font-semibold text-slate-600">
+                          Target amount
+                        </label>
+                        <Input
+                          type="number"
+                          placeholder="1000000"
+                          {...goalForm.register("target_amount")}
+                        />
+                        {goalForm.formState.errors.target_amount ? (
+                          <span className="text-xs text-rose-600">
+                            {goalForm.formState.errors.target_amount.message}
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-semibold text-slate-600">
+                          Target date
+                        </label>
+                        <Input
+                          type="date"
+                          {...goalForm.register("target_date")}
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-semibold text-slate-600">
+                        Notes (optional)
+                      </label>
+                      <Textarea
+                        placeholder="Why this milestone matters to you"
+                        rows={3}
+                        {...goalForm.register("note")}
+                      />
+                    </div>
+                    <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
+                      <span className="font-semibold text-slate-900">
+                        Goal type:
+                      </span>{" "}
+                      Total assets (net worth)
+                    </div>
+                    <DialogFooter>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => setIsDialogOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button type="submit">Save goal</Button>
+                    </DialogFooter>
+                  </form>
+                </DialogContent>
+              </Dialog>
+              <Badge className="gap-2 border-white/20 bg-white/10 text-white">
+                <Trophy className="h-3.5 w-3.5" />
+                {stats.achievedGoals.length} achieved
+              </Badge>
+            </div>
+          </div>
+
+          <div className="space-y-4 rounded-2xl border border-white/15 bg-white/10 p-6 backdrop-blur">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-semibold tracking-[0.2em] text-white/60 uppercase">
+                Current net worth
+              </p>
+              <Award className="h-5 w-5 text-white/70" />
+            </div>
+            <p className="text-3xl font-semibold text-white">
+              {formatCurrency(stats.currentNetWorth)}
+            </p>
+            <Progress
+              value={stats.avgProgress}
+              className="h-2.5 bg-white/15"
+              indicatorClassName="bg-gradient-to-r from-emerald-400 via-cyan-300 to-violet-300"
+            />
+            <div className="flex items-center justify-between text-xs text-white/60">
+              <span>{stats.avgProgress}% of total targets</span>
+              <span>{formatCurrency(stats.totalTarget)} total target</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <Card className="border-slate-200 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+          <CardHeader>
+            <CardTitle className="text-sm text-slate-600">
+              Next milestone
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {stats.nextGoal ? (
+              <>
+                <p className="text-lg font-semibold text-slate-900">
+                  {stats.nextGoal.name}
+                </p>
+                <p className="text-sm text-slate-600">
+                  Target {formatCurrency(stats.nextGoal.target_amount)} by{" "}
+                  {formatDate(stats.nextGoal.target_date)}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-slate-500">
+                Add a dated goal to see your next milestone.
+              </p>
+            )}
           </CardContent>
         </Card>
-      </div>
+        <Card className="border-slate-200 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+          <CardHeader>
+            <CardTitle className="text-sm text-slate-600">
+              Active momentum
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p className="text-2xl font-semibold text-slate-900">
+              {stats.activeGoals.length}
+            </p>
+            <p className="text-sm text-slate-600">
+              Goals still in flight. Keep stacking wins.
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="border-slate-200 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+          <CardHeader>
+            <CardTitle className="text-sm text-slate-600">
+              Pace insight
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {stats.avgDelta !== null ? (
+              <>
+                <p className="text-lg font-semibold text-slate-900">
+                  {formatDelta(stats.avgDelta)}
+                </p>
+                <p className="text-sm text-slate-600">
+                  Average timing across achieved milestones.
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-slate-500">
+                Hit your first goal to unlock timing insights.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </section>
 
       {loading ? (
         <Card className="border-slate-200 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.35)]">
-          <CardContent className="py-6 text-center text-sm text-slate-600">
+          <CardContent className="py-8 text-center text-sm text-slate-600">
             Loading goals...
           </CardContent>
         </Card>
       ) : goals.length === 0 ? (
         <Card className="border-slate-200 shadow-[0_12px_36px_-26px_rgba(15,23,42,0.35)]">
-          <CardContent className="flex flex-col items-center gap-3 py-10 text-center text-slate-600">
-            <GoalIcon className="h-8 w-8 text-slate-500" />
-            <div className="space-y-1">
-              <p className="text-lg font-semibold text-slate-900">
+          <CardContent className="flex flex-col items-center gap-4 py-12 text-center text-slate-600">
+            <GoalIcon className="h-9 w-9 text-slate-500" />
+            <div className="space-y-2">
+              <p className="text-xl font-semibold text-slate-900">
                 No goals yet
               </p>
               <p className="text-sm text-slate-600">
-                Add a target and link it to a category or account to track
-                progress automatically.
+                Add a total assets milestone to start tracking your journey.
               </p>
             </div>
+            <Button onClick={() => setIsDialogOpen(true)}>
+              Create your first goal
+            </Button>
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {goals.map((goal) => {
-            const pct = Math.min(100, Math.round(goal.progress_pct));
-            return (
-              <Card
-                key={goal.id}
-                className="flex h-full flex-col border-slate-200 shadow-[0_16px_40px_-30px_rgba(15,23,42,0.35)]"
-              >
-                <CardHeader className="flex flex-col gap-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
-                      <GoalIcon className="h-4 w-4 text-slate-500" />
-                      <CardTitle className="text-base text-slate-900">
-                        {goal.name}
-                      </CardTitle>
-                    </div>
-                    <Badge variant="outline" className="text-xs">
-                      Target {formatCurrency(goal.target_amount)}
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-slate-500">
-                    {goal.target_date
-                      ? `Due ${formatDate(goal.target_date)}`
-                      : "No due date"}
+        <div className="space-y-8">
+          {stats.activeGoals.length ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    Active goals
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    Keep moving—every step compounds.
                   </p>
-                </CardHeader>
-                <CardContent className="flex flex-1 flex-col gap-3">
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between text-sm text-slate-600">
-                      <span>Progress</span>
-                      <span className="font-semibold text-slate-900">
-                        {formatCurrency(goal.current_amount)} of{" "}
-                        {formatCurrency(goal.target_amount)}
-                      </span>
-                    </div>
-                    <Progress value={pct} />
-                    <div className="flex items-center justify-between text-xs text-slate-500">
-                      <span>{pct}%</span>
-                      <span>{formatDate(goal.target_date)}</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
+                </div>
+                <Badge variant="outline" className="text-xs">
+                  {stats.activeGoals.length} in progress
+                </Badge>
+              </div>
+              <StaggerWrap className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+                {stats.activeGoals.map((goal) => {
+                  const pct = Math.min(100, Math.round(goal.progress_pct));
+                  const remaining = Math.max(
+                    0,
+                    Number(goal.target_amount) - Number(goal.current_amount),
+                  );
+                  return (
+                    <motion.div
+                      key={goal.id}
+                      variants={fadeInUp}
+                      {...subtleHover}
+                    >
+                      <Card className="flex h-full flex-col border-slate-200 bg-white shadow-[0_24px_55px_-35px_rgba(15,23,42,0.35)]">
+                        <CardHeader className="space-y-3">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2">
+                              <Target className="h-4 w-4 text-slate-500" />
+                              <CardTitle className="text-base text-slate-900">
+                                {goal.name}
+                              </CardTitle>
+                            </div>
+                            <Badge className="bg-slate-900 text-white">
+                              {pct}%
+                            </Badge>
+                          </div>
+                          <p className="text-xs text-slate-500">
+                            Target {formatCurrency(goal.target_amount)} •{" "}
+                            {formatDate(goal.target_date)}
+                          </p>
+                        </CardHeader>
+                        <CardContent className="flex flex-1 flex-col gap-4">
+                          <div className="space-y-2">
+                            <div className="flex items-center justify-between text-xs text-slate-500">
+                              <span>Current</span>
+                              <span className="font-semibold text-slate-900">
+                                {formatCurrency(goal.current_amount)}
+                              </span>
+                            </div>
+                            <Progress
+                              value={pct}
+                              className="h-2.5"
+                              indicatorClassName="bg-gradient-to-r from-emerald-500 via-cyan-500 to-violet-500"
+                            />
+                            <div className="flex items-center justify-between text-xs text-slate-500">
+                              <span>{formatCurrency(remaining)} to go</span>
+                              <span>{formatDate(goal.target_date)}</span>
+                            </div>
+                          </div>
+                          {goal.note ? (
+                            <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                              {goal.note}
+                            </div>
+                          ) : null}
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  );
+                })}
+              </StaggerWrap>
+            </div>
+          ) : null}
+
+          {stats.achievedGoals.length ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    Achieved
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    Celebrate the milestones you crushed.
+                  </p>
+                </div>
+                <Badge variant="outline" className="text-xs">
+                  {stats.achievedGoals.length} completed
+                </Badge>
+              </div>
+              <StaggerWrap className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+                {stats.achievedGoals.map((goal) => {
+                  const achievedDate = goal.achieved_at ?? goal.updated_at;
+                  const pct = Math.min(100, Math.round(goal.progress_pct));
+                  return (
+                    <motion.div
+                      key={goal.id}
+                      variants={fadeInUp}
+                      {...subtleHover}
+                    >
+                      <Card className="flex h-full flex-col border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-cyan-50 shadow-[0_30px_70px_-40px_rgba(16,185,129,0.45)]">
+                        <CardHeader className="space-y-3">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2">
+                              <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                              <CardTitle className="text-base text-slate-900">
+                                {goal.name}
+                              </CardTitle>
+                            </div>
+                            <Badge className="border-emerald-200 bg-emerald-100 text-emerald-700">
+                              Done
+                            </Badge>
+                          </div>
+                          <p className="text-xs text-slate-500">
+                            Target {formatCurrency(goal.target_amount)} •{" "}
+                            {formatDate(goal.target_date)}
+                          </p>
+                        </CardHeader>
+                        <CardContent className="flex flex-1 flex-col gap-4">
+                          <div className="space-y-2">
+                            <div className="flex items-center justify-between text-xs text-slate-500">
+                              <span>Achieved</span>
+                              <span className="font-semibold text-slate-900">
+                                {formatDate(achievedDate)}
+                              </span>
+                            </div>
+                            <Progress
+                              value={pct}
+                              className="h-2.5 bg-emerald-100"
+                              indicatorClassName="bg-gradient-to-r from-emerald-500 via-lime-400 to-cyan-400"
+                            />
+                            <div className="flex items-center justify-between text-xs text-slate-500">
+                              <span>
+                                {goal.achieved_delta_days !== null &&
+                                goal.achieved_delta_days !== undefined
+                                  ? formatDelta(goal.achieved_delta_days)
+                                  : "Milestone achieved"}
+                              </span>
+                              <span>{formatCurrency(goal.current_amount)}</span>
+                            </div>
+                          </div>
+                          {goal.note ? (
+                            <div className="rounded-lg border border-emerald-200 bg-white/80 px-3 py-2 text-xs text-emerald-800">
+                              {goal.note}
+                            </div>
+                          ) : null}
+                        </CardContent>
+                      </Card>
+                    </motion.div>
+                  );
+                })}
+              </StaggerWrap>
+            </div>
+          ) : null}
         </div>
       )}
+
+      <section
+        className={cn(
+          "rounded-3xl border border-slate-200 bg-white px-6 py-8 shadow-[0_28px_60px_-45px_rgba(15,23,42,0.25)]",
+          "md:px-10",
+        )}
+      >
+        <div className="grid gap-6 md:grid-cols-[1.4fr_1fr] md:items-center">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase">
+              Motivation boost
+            </p>
+            <h3 className="text-2xl font-semibold text-slate-900">
+              Turn goals into rituals, not reminders.
+            </h3>
+            <p className="text-sm text-slate-600">
+              Keep your milestones visible, celebrate progress, and let the
+              streak build your confidence. Every net worth check-in is a win.
+            </p>
+          </div>
+          <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-5">
+            <div className="flex items-center gap-3">
+              <CalendarClock className="h-5 w-5 text-slate-500" />
+              <div>
+                <p className="text-sm font-semibold text-slate-900">
+                  Upcoming review
+                </p>
+                <p className="text-xs text-slate-500">
+                  Check in monthly to keep momentum strong.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <Trophy className="h-5 w-5 text-slate-500" />
+              <div>
+                <p className="text-sm font-semibold text-slate-900">
+                  Celebrate wins
+                </p>
+                <p className="text-xs text-slate-500">
+                  Every goal reached is proof you can do the next one.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </MotionPage>
   );
 };

--- a/apps/web/src/pages/reports/total/total-reports-page.tsx
+++ b/apps/web/src/pages/reports/total/total-reports-page.tsx
@@ -128,7 +128,6 @@ export const TotalReportsPage: React.FC<TotalReportsPageProps> = ({
     totalKpis,
     totalNetWorthSeries,
     totalNetWorthStats,
-    totalCashflowVolatility,
     totalNetWorthAttribution,
     totalNetWorthTrajectoryData,
     totalNetWorthTrajectoryDomain,

--- a/apps/web/src/types/schemas.ts
+++ b/apps/web/src/types/schemas.ts
@@ -1228,6 +1228,8 @@ export const goalSchema = z.object({
   updated_at: z.string(),
   current_amount: money,
   progress_pct: numeric,
+  achieved_at: nullableString,
+  achieved_delta_days: nullableNumeric,
 });
 
 export const goalListSchema = z.object({


### PR DESCRIPTION
### Motivation
- Focus the goals experience on total assets (net worth) milestones and make the UI motivating and celebratory. 
- Surface historical achievement information so users can see when a milestone was reached and whether it was early/late. 
- Move goal creation into a focused modal UX and provide a modern, animated presentation with shader gradient visual flair. 
- Keep changes minimal but consistent across API, service layer, and frontend types so progress and metadata are available everywhere.

### Description
- Rebuilt the goals UI (`apps/web/src/pages/goals/goals.tsx`) with a shader gradient hero, motivation/insights panels, modal create flow using `Dialog`, animated card lists using `framer-motion`, and distinct active vs achieved card styles. 
- Extended backend progress logic in `GoalService.progress` to return `(current_amount, progress_pct, achieved_at, achieved_delta_days)` and added helper methods `_get_net_worth_history` and `_find_achieved_at` to compute achievements from total net worth when no `account_id`/`category_id`/`subscription_id` is set. 
- Updated API/read schemas to include `achieved_at` and `achieved_delta_days` in `GoalRead` and the frontend `goalSchema` so the UI can display achievement timing. 
- Cleaned a lint issue by removing an unused `totalCashflowVolatility` variable in the total reports page.

### Testing
- Ran `npm run format -w apps/web` to format frontend files and the command completed successfully. 
- Ran `npm run lint -w apps/web` and resolved issues; lint completed successfully afterwards. 
- Ran `make format` and `make type-check` for the backend which formatted Python files and completed type/quality checks with no blocking errors. 
- Launched the dev server and captured a visual verification screenshot via Playwright to confirm the redesigned UI rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695162bbf560832db534e3997d741728)